### PR TITLE
fix: replace `ca` and `resultant_net` int mapping with long

### DIFF
--- a/elasticsearch/mapping_sirene_index.py
+++ b/elasticsearch/mapping_sirene_index.py
@@ -208,7 +208,7 @@ class ElasticsearchEluIndex(InnerDoc):
 
 class BilanFinancierIndex(InnerDoc):
     ca = Long()
-    resultat_net = Integer()
+    resultat_net = Long()
     date_cloture_exercice = Text()
 
 


### PR DESCRIPTION
API return an error with `ca_min` or `ca_max` is higher than `2147483647` (2³¹ – 1).
This PR replaces  `ca`  `int`  mapping type with a `long` type (max 2 to the 63rd power minus 1).
Same with `resultat_net`.