### PR TITLE
fix: add specific start date instead of today

### DIFF
--- a/DAG-insert-elk-sirene.py
+++ b/DAG-insert-elk-sirene.py
@@ -93,7 +93,7 @@ with DAG(
     dag_id=DAG_NAME,
     default_args=default_args,
     schedule_interval="0 0 * * 1,3,5",
-    start_date=datetime.today(),
+    start_date=datetime(2023, 9, 4),
     dagrun_timeout=timedelta(minutes=60 * 15),
     tags=["siren"],
 ) as dag:


### PR DESCRIPTION
When using `today()` as start date, DAG does not run as scheduled.