### PR TITLE
[BUG][ETL]fix: remove bool cast for bool fields

### DIFF
--- a/tests/e2e_tests/response_tester.py
+++ b/tests/e2e_tests/response_tester.py
@@ -69,3 +69,11 @@ class APIResponseTester:
             assert (
                 count >= expected_min_count
             ), f"Expected minimum {expected_min_count} results, but found {count}."
+
+    def test_max_number_of_results(self, path, expected_max_count):
+        response = self.get_api_response(path)
+        if response.status_code == ok_status_code:
+            count = response.json()["total_results"]
+            assert (
+                count <= expected_max_count
+            ), f"Expected maximum {expected_max_count} results, but found {count}."

--- a/tests/e2e_tests/test_api.py
+++ b/tests/e2e_tests/test_api.py
@@ -228,6 +228,9 @@ def test_convention_collective_renseignee(api_response_tester):
     api_response_tester.test_field_value(
         path, "complements.convention_collective_renseignee", True
     )
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
+    path = "/search?convention_collective_renseignee=false"
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
 
 
 def test_departement(api_response_tester):
@@ -240,6 +243,9 @@ def test_departement(api_response_tester):
 def test_egapro_renseignee(api_response_tester):
     path = "/search?egapro_renseignee=true"
     api_response_tester.test_field_value(path, "complements.egapro_renseignee", True)
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
+    path = "/search?egapro_renseignee=false"
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
 
 
 def test_est_association(api_response_tester):
@@ -271,6 +277,9 @@ def test_est_entrepreneur_individuel(api_response_tester):
     api_response_tester.test_field_value(
         path, "complements.est_entrepreneur_individuel", True
     )
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
+    path = "/search?est_entrepreneur_individuel=false"
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
 
 
 def test_est_entrepreneur_spectacle(api_response_tester):
@@ -278,21 +287,39 @@ def test_est_entrepreneur_spectacle(api_response_tester):
     api_response_tester.test_field_value(
         path, "complements.est_entrepreneur_spectacle", True
     )
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
+    path = "/search?est_entrepreneur_spectacle=false"
+    api_response_tester.test_field_value(
+        path, "complements.est_entrepreneur_spectacle", False
+    )
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
 
 
 def test_est_rge(api_response_tester):
     path = "/search?est_rge=true"
     api_response_tester.test_field_value(path, "complements.est_rge", True)
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
+    path = "/search?est_rge=false"
+    api_response_tester.test_field_value(path, "complements.est_rge", False)
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
 
 
 def test_est_finess(api_response_tester):
     path = "/search?est_finess=true"
     api_response_tester.test_field_value(path, "complements.est_finess", True)
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
+    path = "/search?est_finess=false"
+    api_response_tester.test_field_value(path, "complements.est_finess", False)
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
 
 
 def test_est_ess(api_response_tester):
     path = "/search?est_ess=true"
     api_response_tester.test_field_value(path, "complements.est_ess", True)
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
+    path = "/search?est_ess=false"
+    api_response_tester.test_field_value(path, "complements.est_ess", False)
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
 
 
 def test_est_organisme_formation(api_response_tester):
@@ -310,6 +337,10 @@ def test_est_qualiopi(api_response_tester):
 def test_est_uai(api_response_tester):
     path = "/search?est_uai=true"
     api_response_tester.test_field_value(path, "complements.est_uai", True)
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
+    path = "/search?est_uai=false"
+    api_response_tester.test_field_value(path, "complements.est_uai", False)
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
 
 
 def test_etat_administratif(api_response_tester):

--- a/tests/e2e_tests/test_api.py
+++ b/tests/e2e_tests/test_api.py
@@ -100,6 +100,17 @@ def test_organisme_formation(api_response_tester):
     """
     path = "/search?est_organisme_formation=true&est_qualiopi=true"
     api_response_tester.test_number_of_results(path, min_total_results_filters)
+    path = "/search?est_organisme_formation=true&est_qualiopi=false"
+    api_response_tester.test_number_of_results(path, 100)
+    path = "/search?est_organisme_formation=false&est_qualiopi=true"
+    api_response_tester.test_max_number_of_results(path, 0)
+    path = "/search?q=196716856"
+    api_response_tester.test_field_value(path, "complements.est_quliopi", True)
+    path = "/search?q=788945368"
+    api_response_tester.test_field_value(path, "complements.est_quliopi", False)
+    api_response_tester.test_field_value(
+        path, "complements.est_organisme_formation", True
+    )
 
 
 def test_near_point(api_response_tester):
@@ -183,7 +194,9 @@ def test_est_service_public(api_response_tester):
 #     """
 #     path = "/search?est_societe_mission=true"
 #     api_response_tester.test_number_of_results(path, 500)
-#     api_response_tester.test_field_value(path, "complements.est_societe_mission", True)
+#     api_response_tester.test_field_value(
+#       path, "complements.est_societe_mission", True
+#       )
 
 
 def test_commune_filter(api_response_tester):

--- a/tests/e2e_tests/test_api.py
+++ b/tests/e2e_tests/test_api.py
@@ -261,6 +261,9 @@ def test_est_collectivite_territoriale(api_response_tester):
 def test_est_bio(api_response_tester):
     path = "/search?est_bio=true"
     api_response_tester.test_field_value(path, "complements.est_bio", True)
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
+    path = "/search?est_bio=false"
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
 
 
 def test_est_entrepreneur_individuel(api_response_tester):

--- a/workflows/data_pipelines/etl/data_fetch_clean/convention_collective.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/convention_collective.py
@@ -3,7 +3,6 @@ from dag_datalake_sirene.config import URL_MINIO_CONVENTION_COLLECTIVE
 
 
 def preprocess_convcollective_data(data_dir):
-
     df_cc = pd.read_csv(
         URL_MINIO_CONVENTION_COLLECTIVE,
         dtype=str,

--- a/workflows/data_pipelines/etl/data_fetch_clean/egapro.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/egapro.py
@@ -4,6 +4,4 @@ from dag_datalake_sirene.config import URL_MINIO_EGAPRO
 
 def preprocess_egapro_data(data_dir):
     df_egapro = pd.read_csv(URL_MINIO_EGAPRO, dtype=str)
-    df_egapro["egapro_renseignee"] = df_egapro["egapro_renseignee"].astype(bool)
-
     return df_egapro

--- a/workflows/data_pipelines/etl/data_fetch_clean/egapro.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/egapro.py
@@ -3,5 +3,7 @@ from dag_datalake_sirene.config import URL_MINIO_EGAPRO
 
 
 def preprocess_egapro_data(data_dir):
-    df_egapro = pd.read_csv(URL_MINIO_EGAPRO, dtype=str)
+    df_egapro = pd.read_csv(
+        URL_MINIO_EGAPRO, dtype={"siren": "object", "egapro_renseignee": "bool"}
+    )
     return df_egapro

--- a/workflows/data_pipelines/etl/data_fetch_clean/entrepreneur_spectacle.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/entrepreneur_spectacle.py
@@ -7,7 +7,7 @@ def preprocess_spectacle_data(data_dir):
         URL_MINIO_ENTREPRENEUR_SPECTACLE,
         dtype={
             "siren": "object",
-            "statut_entrepreneur_spectacle": "bool",
+            "statut_entrepreneur_spectacle": "object",
             "est_entrepreneur_spectacle": "bool",
         },
     )

--- a/workflows/data_pipelines/etl/data_fetch_clean/entrepreneur_spectacle.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/entrepreneur_spectacle.py
@@ -3,5 +3,13 @@ from dag_datalake_sirene.config import URL_MINIO_ENTREPRENEUR_SPECTACLE
 
 
 def preprocess_spectacle_data(data_dir):
-    df_spectacle = pd.read_csv(URL_MINIO_ENTREPRENEUR_SPECTACLE, dtype=str)
+    df_spectacle = pd.read_csv(
+        URL_MINIO_ENTREPRENEUR_SPECTACLE,
+        dtype={
+            "siren": "object",
+            "statut_entrepreneur_spectacle": "bool",
+            "est_entrepreneur_spectacle": "bool",
+        },
+    )
+
     return df_spectacle

--- a/workflows/data_pipelines/etl/data_fetch_clean/entrepreneur_spectacle.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/entrepreneur_spectacle.py
@@ -4,8 +4,4 @@ from dag_datalake_sirene.config import URL_MINIO_ENTREPRENEUR_SPECTACLE
 
 def preprocess_spectacle_data(data_dir):
     df_spectacle = pd.read_csv(URL_MINIO_ENTREPRENEUR_SPECTACLE, dtype=str)
-    df_spectacle["est_entrepreneur_spectacle"] = df_spectacle[
-        "est_entrepreneur_spectacle"
-    ].astype(bool)
-
     return df_spectacle

--- a/workflows/data_pipelines/etl/data_fetch_clean/ess_france.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/ess_france.py
@@ -3,5 +3,11 @@ from dag_datalake_sirene.config import URL_MINIO_ESS_FRANCE
 
 
 def preprocess_ess_france_data(data_dir):
-    df_ess = pd.read_csv(URL_MINIO_ESS_FRANCE, dtype=str)
+    df_ess = pd.read_csv(
+        URL_MINIO_ESS_FRANCE,
+        dtype={
+            "siren": "object",
+            "est_ess_france": "bool",
+        },
+    )
     return df_ess

--- a/workflows/data_pipelines/etl/data_fetch_clean/ess_france.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/ess_france.py
@@ -4,5 +4,4 @@ from dag_datalake_sirene.config import URL_MINIO_ESS_FRANCE
 
 def preprocess_ess_france_data(data_dir):
     df_ess = pd.read_csv(URL_MINIO_ESS_FRANCE, dtype=str)
-
     return df_ess

--- a/workflows/data_pipelines/etl/data_fetch_clean/finess.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/finess.py
@@ -4,5 +4,4 @@ from dag_datalake_sirene.config import URL_MINIO_FINESS
 
 def preprocess_finess_data(data_dir):
     df_finess = pd.read_csv(URL_MINIO_FINESS, dtype=str)
-
     return df_finess

--- a/workflows/data_pipelines/etl/data_fetch_clean/organisme_formation.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/organisme_formation.py
@@ -4,9 +4,4 @@ from dag_datalake_sirene.config import URL_MINIO_ORGANISME_FORMATION
 
 def preprocess_organisme_formation_data(data_dir):
     df_organisme_formation = pd.read_csv(URL_MINIO_ORGANISME_FORMATION, dtype=str)
-    # Convert 'est_qualiopi' column to boolean dtype
-    df_organisme_formation["est_qualiopi"] = df_organisme_formation[
-        "est_qualiopi"
-    ].astype(bool)
-
     return df_organisme_formation

--- a/workflows/data_pipelines/etl/data_fetch_clean/organisme_formation.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/organisme_formation.py
@@ -3,5 +3,12 @@ from dag_datalake_sirene.config import URL_MINIO_ORGANISME_FORMATION
 
 
 def preprocess_organisme_formation_data(data_dir):
-    df_organisme_formation = pd.read_csv(URL_MINIO_ORGANISME_FORMATION, dtype=str)
+    df_organisme_formation = pd.read_csv(
+        URL_MINIO_ORGANISME_FORMATION,
+        dtype={
+            "siren": "object",
+            "liste_id_organisme_formation": "object",
+            "est_qualiopi": "bool",
+        },
+    )
     return df_organisme_formation

--- a/workflows/data_pipelines/etl/data_fetch_clean/rge.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/rge.py
@@ -4,5 +4,4 @@ from dag_datalake_sirene.config import URL_MINIO_RGE
 
 def preprocess_rge_data(data_dir):
     df_rge = pd.read_csv(URL_MINIO_RGE, dtype=str)
-
     return df_rge


### PR DESCRIPTION
The bug originated in the `Organisme de formation` data, which includes a boolean column with `True` or `False` values. When the CSV file is imported, all columns are initially cast as strings. I added a line of code to cast the `est_qualiopi` column as a boolean, but this resulted in the entire column being set to `True`. Consequently, all `organisme de formation` entries have been incorrectly labeled as `qualiopi` for the past two weeks.

The same boolean casting code was applied to other data sources, but it did not cause any critical issues since those columns already contained only `True` values. This pull request removes the boolean casting line from those data sources for consistency.