### PR TITLE
[RNE][OPTIMISATION]Remove duplicates from rne db before uploading to MinIO

### DIFF
--- a/workflows/data_pipelines/rne/database/DAG.py
+++ b/workflows/data_pipelines/rne/database/DAG.py
@@ -10,6 +10,7 @@ from dag_datalake_sirene.workflows.data_pipelines.rne.database.task_functions im
     create_db,
     process_flux_json_files,
     process_stock_json_files,
+    remove_duplicates,
     upload_db_to_minio,
     upload_latest_date_rne_minio,
     notification_tchap,
@@ -53,6 +54,10 @@ with DAG(
     process_flux_json_files = PythonOperator(
         task_id="process_flux_json_files", python_callable=process_flux_json_files
     )
+
+    remove_duplicates = PythonOperator(
+        task_id="remove_duplicates", python_callable=remove_duplicates
+    )
     check_db_count = PythonOperator(
         task_id="check_db_count", python_callable=check_db_count
     )
@@ -78,7 +83,8 @@ with DAG(
     get_latest_db.set_upstream(create_db)
     process_stock_json_files.set_upstream(get_latest_db)
     process_flux_json_files.set_upstream(process_stock_json_files)
-    check_db_count.set_upstream(process_flux_json_files)
+    remove_duplicates.set_upstream(process_flux_json_files)
+    check_db_count.set_upstream(remove_duplicates)
     upload_db_to_minio.set_upstream(check_db_count)
     upload_latest_date_rne_minio.set_upstream(upload_db_to_minio)
     clean_outputs.set_upstream(upload_latest_date_rne_minio)

--- a/workflows/data_pipelines/rne/database/process_rne.py
+++ b/workflows/data_pipelines/rne/database/process_rne.py
@@ -550,11 +550,6 @@ def remove_duplicates_from_tables(cursor, table_name):
     # Insert distinct rows into the temporary table
     cursor.execute(f"INSERT INTO {temp_table} SELECT DISTINCT * FROM {table_name}")
 
-    # Get the list of indexes from the original table
-    cursor.execute(
-        f"SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name='{table_name}'"
-    )
-
     # Drop the original table
     cursor.execute(f"DROP TABLE {table_name}")
 

--- a/workflows/data_pipelines/rne/database/process_rne.py
+++ b/workflows/data_pipelines/rne/database/process_rne.py
@@ -543,9 +543,14 @@ def remove_duplicates_from_tables(cursor, table_name):
     )
     create_table_sql = cursor.fetchone()[0]
 
-    # Create a temporary table with the same schema
+    # Modify the SQL to create the temporary table without altering column names
     temp_table = f"{table_name}_temp"
-    cursor.execute(f"{create_table_sql.replace(table_name, temp_table)}")
+    create_temp_table_sql = create_table_sql.replace(
+        f"CREATE TABLE {table_name}", f"CREATE TABLE {temp_table}"
+    )
+
+    # Create the temporary table with the modified schema
+    cursor.execute(create_temp_table_sql)
 
     # Insert distinct rows into the temporary table
     cursor.execute(f"INSERT INTO {temp_table} SELECT DISTINCT * FROM {table_name}")

--- a/workflows/data_pipelines/rne/database/task_functions.py
+++ b/workflows/data_pipelines/rne/database/task_functions.py
@@ -11,6 +11,7 @@ from dag_datalake_sirene.workflows.data_pipelines.rne.database.process_rne impor
     create_tables,
     get_tables_count,
     inject_records_into_db,
+    remove_duplicates_from_tables,
 )
 from dag_datalake_sirene.workflows.data_pipelines.rne.database.db_connexion import (
     connect_to_db,
@@ -240,37 +241,6 @@ def process_flux_json_files(**kwargs):
     kwargs["ti"].xcom_push(key="last_date_processed", value=last_date_processed)
 
 
-def remove_duplicates_from_table(cursor, table_name):
-    # Get the schema of the original table
-    cursor.execute(
-        f"SELECT sql FROM sqlite_master WHERE type='table' AND name='{table_name}'"
-    )
-    create_table_sql = cursor.fetchone()[0]
-
-    # Create a temporary table with the same schema
-    temp_table = f"{table_name}_temp"
-    cursor.execute(f"{create_table_sql.replace(table_name, temp_table)}")
-
-    # Insert distinct rows into the temporary table
-    cursor.execute(f"INSERT INTO {temp_table} SELECT DISTINCT * FROM {table_name}")
-
-    # Get the list of indexes from the original table
-    cursor.execute(
-        f"SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name='{table_name}'"
-    )
-    indexes = cursor.fetchall()
-
-    # Drop the original table
-    cursor.execute(f"DROP TABLE {table_name}")
-
-    # Rename the temporary table to the original table name
-    cursor.execute(f"ALTER TABLE {temp_table} RENAME TO {table_name}")
-
-    # Recreate the indexes
-    for index in indexes:
-        cursor.execute(index[0])
-
-
 def remove_duplicates(**kwargs):
     rne_db_path = kwargs["ti"].xcom_pull(key="rne_db_path", task_ids="create_db")
     connection, cursor = connect_to_db(rne_db_path)
@@ -286,7 +256,7 @@ def remove_duplicates(**kwargs):
     try:
         for table in tables:
             logging.info(f"Cleaning table: {table}")
-            remove_duplicates_from_table(cursor, table)
+            remove_duplicates_from_tables(cursor, table)
         connection.commit()
         # Vacuum the database to reclaim space
         cursor.execute("VACUUM")

--- a/workflows/data_pipelines/rne/database/task_functions.py
+++ b/workflows/data_pipelines/rne/database/task_functions.py
@@ -288,6 +288,9 @@ def remove_duplicates(**kwargs):
             logging.info(f"Cleaning table: {table}")
             remove_duplicates_from_table(cursor, table)
         connection.commit()
+        # Vacuum the database to reclaim space
+        cursor.execute("VACUUM")
+        connection.commit()
     except Exception as e:
         connection.rollback()
         logging.warning(f"Error when removing duplicates: {e}")


### PR DESCRIPTION
closes #336 
The previous strategy involved deleting records with the same SIREN but different JSON files, based on the assumption that the API only returns a SIREN once a day. However, it has been discovered that one JSON RNE file (a flux from one day) can contain the same records multiple times, sometimes up to ten times. This redundancy has caused the database size to become unmanageably large.

This PR addresses the issue by removing exact duplicates (same SIREN, same source file, same data) from the RNE database after all processing is complete, just before the database is uploaded to MinIO. Testing in dev environment showed a significant reduction in database file size from **170 GB to 36 GB, an 80% decrease**. This optimisation also results in considerable time savings for zipping, unzipping, uploading, and downloading the file in other workflows, such as ETL processes.