### PR TITLE
[FIX][DATA-PIPELINES]Handle http errors in API calls

### DIFF
--- a/workflows/data_pipelines/agence_bio/task_functions.py
+++ b/workflows/data_pipelines/agence_bio/task_functions.py
@@ -40,13 +40,20 @@ def process_agence_bio(ti, max_retries=5):
                 time.sleep(30)
                 retry_attempt += 1
                 continue
-            else:
-                break
+            r.raise_for_status()
+            try:
+                data = r.json()
+            except requests.exceptions.JSONDecodeError as e:
+                logging.error(f"Failed to decode JSON response: {e}")
+                raise
         except requests.RequestException as e:
             logging.error(f"An error occurred: {e}")
             time.sleep(30)  # Sleep before retrying in case of request exceptions
             retry_attempt += 1
-    data = r.json()
+    else:
+        # If while loop exited without breaking, it means retries were exhausted
+        raise Exception("Max retries exceeded for endpoint.")
+
     res = data["items"]
     while data["items"]:
         print(cpt)

--- a/workflows/data_pipelines/agence_bio/task_functions.py
+++ b/workflows/data_pipelines/agence_bio/task_functions.py
@@ -43,11 +43,12 @@ def process_agence_bio(ti, max_retries=5):
             r.raise_for_status()
             try:
                 data = r.json()
+                break
             except requests.exceptions.JSONDecodeError as e:
                 logging.error(f"Failed to decode JSON response: {e}")
                 raise
         except requests.RequestException as e:
-            logging.error(f"An error occurred: {e}")
+            logging.error(f"An unexpected error occurred: {e}")
             time.sleep(30)  # Sleep before retrying in case of request exceptions
             retry_attempt += 1
     else:
@@ -56,7 +57,7 @@ def process_agence_bio(ti, max_retries=5):
 
     res = data["items"]
     while data["items"]:
-        print(cpt)
+        logging.info(f"Number of resutls : {cpt}")
         cpt += 1000
         r = requests.get(f"{url}{str(cpt)}")
         data = r.json()

--- a/workflows/data_pipelines/sirene/flux/DAG.py
+++ b/workflows/data_pipelines/sirene/flux/DAG.py
@@ -14,6 +14,7 @@ from dag_datalake_sirene.workflows.data_pipelines.sirene.flux.task_functions imp
     get_stock_non_diffusible,
     send_flux_minio,
     send_stock_minio,
+    send_notification_failure_tchap,
 )
 
 from dag_datalake_sirene.helpers.utils import (
@@ -43,6 +44,9 @@ with DAG(
     start_date=days_ago(1),
     dagrun_timeout=timedelta(minutes=60 * 5),
     tags=["sirene", "flux"],
+    catchup=False,
+    on_failure_callback=send_notification_failure_tchap,
+    max_active_runs=1,
 ) as dag:
     clean_previous_outputs = BashOperator(
         task_id="clean_previous_outputs",

--- a/workflows/data_pipelines/sirene/flux/DAG.py
+++ b/workflows/data_pipelines/sirene/flux/DAG.py
@@ -20,6 +20,7 @@ from dag_datalake_sirene.helpers.utils import (
     check_if_monday,
 )
 from dag_datalake_sirene.config import (
+    EMAIL_LIST,
     INSEE_FLUX_TMP_FOLDER,
 )
 
@@ -31,6 +32,7 @@ default_args = {
     "email_on_retry": False,
     "retries": 1,
     "retry_delay": timedelta(minutes=5),
+    "email": EMAIL_LIST,
 }
 
 

--- a/workflows/data_pipelines/sirene/flux/task_functions.py
+++ b/workflows/data_pipelines/sirene/flux/task_functions.py
@@ -64,6 +64,10 @@ def call_insee_api(api_endpoint, data_property, max_retries=10):
                 logging.error(f"An error occurred: {e}")
                 time.sleep(30)  # Sleep before retrying in case of request exceptions
                 retry_attempt += 1
+        else:
+            # If while loop exited without breaking, it means retries were exhausted
+            raise Exception(f"Max retries exceeded for endpoint {api_endpoint}.")
+
         response_json = api_response.json()
 
         if (

--- a/workflows/data_pipelines/sirene/flux/task_functions.py
+++ b/workflows/data_pipelines/sirene/flux/task_functions.py
@@ -35,7 +35,7 @@ def flatten_dict(dd, separator="_", prefix=""):
     )
 
 
-def call_insee_api(api_endpoint, data_property):
+def call_insee_api(api_endpoint, data_property, max_retries=10):
     current_cursor = "*"
     api_data = []
     api_headers = {"Authorization": f"Bearer {INSEE_SECRET_BEARER}"}
@@ -47,8 +47,23 @@ def call_insee_api(api_endpoint, data_property):
         if request_count % 10000 == 0:
             logging.info(request_count)
 
-        api_response = session.get(api_endpoint + current_cursor, headers=api_headers)
-        time.sleep(0.5)
+        retry_attempt = 0
+        while retry_attempt <= max_retries:
+            try:
+                api_response = session.get(
+                    api_endpoint + current_cursor, headers=api_headers
+                )
+                if api_response.status_code == 429:
+                    logging.warning("Rate limit exceeded. Sleeping for 10 seconds...")
+                    time.sleep(10)
+                    retry_attempt += 1
+                    continue
+                else:
+                    break
+            except requests.RequestException as e:
+                logging.error(f"An error occurred: {e}")
+                time.sleep(30)  # Sleep before retrying in case of request exceptions
+                retry_attempt += 1
         response_json = api_response.json()
 
         if (

--- a/workflows/data_pipelines/sirene/flux/task_functions.py
+++ b/workflows/data_pipelines/sirene/flux/task_functions.py
@@ -299,3 +299,7 @@ def send_notification_stock(ti):
         f"\U0001F7E2 Données flux Sirene mises à jour."
         f"- {nb_stock_non_diffusible} unités légales non diffusibles."
     )
+
+
+def send_notification_failure_tchap(context):
+    send_message("\U0001F534 Données :" "\nFail DAG de flux sirene!!!!")


### PR DESCRIPTION
This PR includes the following updates:

- **Enhanced Error Handling**: Implements handling for HTTP 429 errors (rate limiting) from the Sirene API. It includes a retry mechanism with a delay to manage rate limits effectively. Same for API Bio.
- **Notification Improvements**: Adds functionality to send notifications to Tchap in the event of a failure in the Sirene flux workflow. Additionally, it introduces an email variable that was previously omitted in the settings, which resolves issues with missing email notifications for failed workflows.
