### PR TITLE
[INSEE]chore: block flux sirene execution on the 1st of every month

### DIFF
--- a/workflows/data_pipelines/sirene/flux/DAG.py
+++ b/workflows/data_pipelines/sirene/flux/DAG.py
@@ -40,7 +40,7 @@ default_args = {
 with DAG(
     dag_id=DAG_NAME,
     default_args=default_args,
-    schedule_interval="0 4 * * *",  # Daily at 4 AM
+    schedule_interval="0 4 2-31 * *",  # Daily at 4 AM except the 1st of every month
     start_date=days_ago(1),
     dagrun_timeout=timedelta(minutes=60 * 5),
     tags=["sirene", "flux"],


### PR DESCRIPTION
This PR halts the execution of Flux Sirene on the first day of each month to prevent errors caused by the recently published stock data.