### PR TITLE
[FIX]Reschedule ETL for later in the morning

### DIFF
--- a/workflows/data_pipelines/etl/DAG_extract_transform_load.py
+++ b/workflows/data_pipelines/etl/DAG_extract_transform_load.py
@@ -97,7 +97,7 @@ default_args = {
 with DAG(
     dag_id=AIRFLOW_ETL_DAG_NAME,
     default_args=default_args,
-    schedule_interval="0 5 * * *",  # Run everyday at 5 am
+    schedule_interval="0 9 * * *",  # Run everyday at 9 am
     start_date=datetime(2023, 12, 27),
     dagrun_timeout=timedelta(minutes=60 * 5),
     tags=["database", "all-data"],


### PR DESCRIPTION
Due to API instabilities (slower response) caused by the snapshot import around 15:30, this PR reschedules the ETL from 5:00 AM to 9:00 AM. The ETL process takes approximately 3 hours, and indexing requires about 7 hours, which shifts the snapshot workflow trigger to around 19:00. This is a temporary solution until the root cause of the issue is identified.