### PR TITLE
[CHORE]Add Tchap failure notifications to agence bio workflow

### DIFF
--- a/helpers/tchap.py
+++ b/helpers/tchap.py
@@ -35,3 +35,9 @@ def send_message(
     except requests.exceptions.RequestException as e:
         logging.error(f"Failed to send message: {e}")
         raise Exception(f"Failed to send message: {e}")
+
+
+def send_notification_failure_tchap(context):
+    dag_id = context["dag"].dag_id  # Get the dag_id from the context
+    message = f"\U0001F534 Fail DAG: {dag_id}!!!!"
+    send_message(message)

--- a/workflows/data_pipelines/agence_bio/DAG.py
+++ b/workflows/data_pipelines/agence_bio/DAG.py
@@ -14,6 +14,7 @@ from dag_datalake_sirene.workflows.data_pipelines.agence_bio.task_functions impo
     compare_files_minio,
     send_notification,
 )
+from dag_datalake_sirene.helpers.tchap import send_notification_failure_tchap
 
 default_args = {
     "depends_on_past": False,
@@ -32,6 +33,7 @@ with DAG(
     tags=["agence bio", "certifications"],
     params={},
     catchup=False,
+    on_failure_callback=send_notification_failure_tchap,
 ) as dag:
     clean_previous_outputs = BashOperator(
         task_id="clean_previous_outputs",


### PR DESCRIPTION
Previously, notifications were only sent via email. This PR introduces a Tchap notification to ensure the information is shared more effectively.