### PR TITLE
[BUG]Skip flow sirene in the beginning of the month

### DIFF
--- a/workflows/data_pipelines/etl/DAG_extract_transform_load.py
+++ b/workflows/data_pipelines/etl/DAG_extract_transform_load.py
@@ -144,12 +144,14 @@ with DAG(
         task_id="create_flux_etablissement_table",
         provide_context=True,
         python_callable=create_flux_etablissement_table,
+        trigger_rule="all_done",
     )
 
     replace_unite_legale_table = PythonOperator(
         task_id="replace_unite_legale_table",
         provide_context=True,
         python_callable=replace_unite_legale_table,
+        trigger_rule="all_done",
     )
 
     replace_etablissement_table = PythonOperator(
@@ -216,6 +218,7 @@ with DAG(
         task_id="create_historique_etablissement_table",
         provide_context=True,
         python_callable=create_historique_etablissement_table,
+        trigger_rule="all_done",
     )
 
     create_date_fermeture_etablissement_table = PythonOperator(


### PR DESCRIPTION
At the start of each month, a new Sirene stock file is usually published on data.gouv on the 1st. When querying the Sirene API for the differential between the last day of the previous month and the first day of the new month, an error occurs. This API error results in the absence of the new flux files on MinIO between the last day of the month and the 2nd of the new month. Consequently, this causes an issue when trying to create the flux tables (ul, etab, and siege).

This PR resolves the issue by skipping the task of filling (but still creating) flux tables if the new month's flux files are not yet found on MinIO. It ensures that the subsequent tasks can execute smoothly, even if the files are missing during this transition period.