### PR TITLE
[PERFORMANCE]chore: delay etl dag by one hour

### DIFF
--- a/workflows/data_pipelines/etl/DAG_extract_transform_load.py
+++ b/workflows/data_pipelines/etl/DAG_extract_transform_load.py
@@ -103,7 +103,7 @@ default_args = {
 with DAG(
     dag_id=AIRFLOW_ETL_DAG_NAME,
     default_args=default_args,
-    schedule_interval="0 9 * * *",  # Run everyday at 9 am
+    schedule_interval="0 10 * * *",  # Run everyday at 10 am
     start_date=datetime(2023, 12, 27),
     dagrun_timeout=timedelta(minutes=60 * 5),
     tags=["database", "all-data"],


### PR DESCRIPTION
Indexing should end later in the evening to avoid latency on Elasticsearch.