### PR TITLE
[BILANS-FINANCIERS]fix: handle BOM in csv file by using utf-8-sig encoding

### DIFF
--- a/workflows/data_pipelines/bilans_financiers/task_functions.py
+++ b/workflows/data_pipelines/bilans_financiers/task_functions.py
@@ -48,6 +48,7 @@ def process_bilans_financiers(ti):
         dtype=str,
         sep=";",
         usecols=fields,
+        encoding="utf-8-sig",
     )
 
     df_bilan = df_bilan.rename(
@@ -179,6 +180,6 @@ def compare_files_minio():
 def send_notification(ti):
     nb_siren = ti.xcom_pull(key="nb_siren", task_ids="process_bilans_financiers")
     send_message(
-        f"\U0001F7E2 Données Bilans Financiers mises à jour.\n"
+        f"\U0001f7e2 Données Bilans Financiers mises à jour.\n"
         f"- {nb_siren} unités légales référencés\n"
     )


### PR DESCRIPTION
This PR addresses an issue encountered when reading the CSV file bilans_entreprises.csv in the process_bilans_financiers function. The original implementation resulted in a ValueError due to a mismatch between the expected column names and the actual column names in the CSV file, which was caused by the presence of a Byte Order Mark (BOM) at the beginning of the file.

Changes Made:

Updated  function to use the encoding='utf-8-sig' parameter. This change ensures that any BOM present in the CSV file is automatically detected and removed, allowing for proper reading of the file without causing errors related to column name mismatch.