### PR TITLE
[SIRENE][FLUX]fix: increase dag timeout

### DIFF
--- a/workflows/data_pipelines/sirene/flux/dag.py
+++ b/workflows/data_pipelines/sirene/flux/dag.py
@@ -24,7 +24,7 @@ default_args = {
     default_args=default_args,
     schedule_interval="0 4 2-31 * *",  # Daily at 4 AM except the 1st of every month
     start_date=days_ago(1),
-    dagrun_timeout=timedelta(minutes=60 * 5),
+    dagrun_timeout=timedelta(minutes=60 * 12),
     params={},
     catchup=False,
     max_active_runs=1,


### PR DESCRIPTION
This PR addresses the recurring zombie task error encountered when processing large `etablissements` data from Insee in the `get_flux_etablissements` task. The issue arises due to the size of the dataset causing the task to exceed heartbeat or timeout thresholds, leaving it in an inconsistent state.