### PR TITLE
[BUG]fix(sirene): save flux data in chunks to avoid memory issues

### DIFF
--- a/helpers/api_client.py
+++ b/helpers/api_client.py
@@ -41,7 +41,7 @@ def retry_request(
                             sleep_time = backoff_factor * (2**retries)
                             logging.warning(
                                 f"Retryable error: {response.status_code}. "
-                                "Sleeping for {sleep_time} seconds..."
+                                f"Sleeping for {sleep_time} seconds..."
                             )
                             time.sleep(sleep_time)
                         case 500:

--- a/workflows/data_pipelines/sirene/flux/api.py
+++ b/workflows/data_pipelines/sirene/flux/api.py
@@ -4,6 +4,7 @@ from dag_datalake_sirene.helpers.api_client import ApiClient
 from dag_datalake_sirene.helpers.utils import (
     flatten_dict,
 )
+import logging
 
 
 class SireneApiClient(ApiClient):
@@ -25,18 +26,37 @@ class SireneApiClient(ApiClient):
     def fetch_data(self, endpoint: str, data_property: str) -> pd.DataFrame:
         """Fetch data from the INSEE API, flatten it, and return it as a DataFrame."""
         data = self.call_insee_api(endpoint, data_property)
-        # Flatten the data before converting to DataFrame
+        # Process data in chunks to avoid memory issues
+        chunk_size = 100000
+
         if data_property == "unitesLegales":
             flux = [
                 flatten_dict({**entry, **entry.get("periodesUniteLegale", [{}])[0]})
                 for entry in data
             ]
+            return pd.DataFrame(flux)
         elif data_property == "etablissements":
-            flux = [
-                flatten_dict({**entry, **entry.get("periodesEtablissement", [{}])[0]})
-                for entry in data
-            ]
-        return pd.DataFrame(flux)
+            logging.info(
+                f"Processing {len(data)} etablissements in chunks of {chunk_size}"
+            )
+            dfs = []
+            for i in range(0, len(data), chunk_size):
+                chunk = data[i : i + chunk_size]
+                chunk_df = pd.DataFrame(
+                    [
+                        flatten_dict(
+                            {**entry, **entry.get("periodesEtablissement", [{}])[0]}
+                        )
+                        for entry in chunk
+                    ]
+                )
+                dfs.append(chunk_df)
+                logging.info(
+                    f"Processed chunk {i//chunk_size + 1} of {(len(data)-1)//chunk_size + 1}"
+                )
+
+            # Concatenate all chunks
+            return pd.concat(dfs, ignore_index=True)
 
     def process_response_and_pagination(
         self, response: dict[str, Any] = None, current_params: dict[str, Any] = None

--- a/workflows/data_pipelines/sirene/flux/processor.py
+++ b/workflows/data_pipelines/sirene/flux/processor.py
@@ -83,7 +83,6 @@ class SireneFluxProcessor(DataProcessor):
             df.columns = [
                 col.replace(prefix, "") if prefix in col else col for col in df.columns
             ]
-
         save_data_to_zipped_csv(
             df, self.config.tmp_folder, f"flux_etablissement_{self.current_month}.csv"
         )


### PR DESCRIPTION
related to https://github.com/annuaire-entreprises-data-gouv-fr/search-infra/pull/462

This PR addresses the recurring zombie task error encountered when processing large etablissements data from Insee in the get_flux_etablissements task. The issue arises due to the size of the list when converted to a pandas df.