### PR TITLE
[BUG] Fix get flux etablissements RAM usage issue

### DIFF
--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -263,22 +263,23 @@ def flatten_dict(dd, separator="_", prefix=""):
     )
 
 
-def save_dataframe_zipped(df: pd.DataFrame, file_path: str, chunk_size: int = 100000):
-    df.to_csv(file_path, index=False)
-
+def zip_file(file_path: str, chunk_size: int = 100000):
+    zip_path = f"{file_path}.gz"
     with open(file_path, "rb") as orig_file:
-        with gzip.open(f"{file_path}.gz", "wb") as zipped_file:
+        with gzip.open(zip_path, "wb") as zipped_file:
             while True:
                 chunk = orig_file.read(chunk_size)
                 if not chunk:
                     break
                 zipped_file.write(chunk)
+    return zip_path
 
 
 def save_data_to_zipped_csv(df: pd.DataFrame, folder: str, filename: str):
     """Save DataFrame to CSV and log the action."""
-    file_path = os.path.join(folder, filename)
-    save_dataframe_zipped(df, file_path)
+    file_path: str = os.path.join(folder, filename)
+    df.to_csv(file_path, index=False)
+    zip_file(file_path)
     logging.info(f"Saved {filename} with {df.shape[0]} records.")
 
 
@@ -527,3 +528,24 @@ def download_file(download_url: str, destination_path: str) -> None:
             file.write(chunk)
 
     logging.info(f"..download successful! File located in {destination_path}.")
+
+
+def get_dates_since_start_of_month() -> list[str]:
+    """
+    Get the dates since the beginning of the month until today.
+
+    Returns:
+        list[str]: List of dates with YYYY-MM-DD string format.
+    """
+    today = datetime.today()
+    # Get the first day of the current month
+    first_day_of_month = today.replace(day=1)
+
+    # Generate the list of dates
+    dates: list[str] = []
+    date = first_day_of_month
+    while date <= today:
+        dates.append(date.strftime("%Y-%m-%d"))
+        date += timedelta(days=1)
+
+    return dates

--- a/workflows/data_pipelines/agence_bio/processor.py
+++ b/workflows/data_pipelines/agence_bio/processor.py
@@ -187,15 +187,15 @@ class AgenceBioProcessor(DataProcessor):
             df.to_csv(file_path, index=False)
             logging.info(f"Saved {name} data to {file_path}")
 
-        DataProcessor.push_unique_count(
-            processed_data["principal"]["id_bio"],
+        DataProcessor.push_message(
             Notification.notification_xcom_key,
-            "identifiants bio",
+            column=processed_data["principal"]["id_bio"],
+            description="identifiants bio",
         )
-        DataProcessor.push_unique_count(
-            processed_data["principal"]["siret"],
+        DataProcessor.push_message(
             Notification.notification_xcom_key,
-            "siret",
+            column=processed_data["principal"]["siret"],
+            description="siret",
         )
 
     def send_file_to_minio(self) -> None:

--- a/workflows/data_pipelines/bilans_financiers/processor.py
+++ b/workflows/data_pipelines/bilans_financiers/processor.py
@@ -98,6 +98,7 @@ class BilansFinanciersProcessor(DataProcessor):
             index=False,
         )
 
-        DataProcessor.push_unique_count(
-            df_bilan.siren, Notification.notification_xcom_key
+        DataProcessor.push_message(
+            Notification.notification_xcom_key,
+            column=df_bilan.siren,
         )

--- a/workflows/data_pipelines/convcollective/processor.py
+++ b/workflows/data_pipelines/convcollective/processor.py
@@ -62,4 +62,7 @@ class ConventionCollectiveProcessor(DataProcessor):
 
         df_cc.to_csv(self.config.file_output, index=False)
 
-        DataProcessor.push_unique_count(df_cc.siren, Notification.notification_xcom_key)
+        DataProcessor.push_message(
+            Notification.notification_xcom_key,
+            column=df_cc.siren,
+        )

--- a/workflows/data_pipelines/egapro/processor.py
+++ b/workflows/data_pipelines/egapro/processor.py
@@ -20,8 +20,10 @@ class EgaproProcessor(DataProcessor):
         df_egapro = df_egapro.rename(columns={"SIREN": "siren"})
         df_egapro.to_csv(f"{self.config.tmp_folder}/egapro.csv", index=False)
 
-        DataProcessor.push_unique_count(
-            df_egapro["siren"], Notification.notification_xcom_key, "unités légales"
+        DataProcessor.push_message(
+            Notification.notification_xcom_key,
+            column=df_egapro["siren"],
+            description="unités légales",
         )
 
         del df_egapro

--- a/workflows/data_pipelines/ess_france/processor.py
+++ b/workflows/data_pipelines/ess_france/processor.py
@@ -17,7 +17,9 @@ class EssFranceProcessor(DataProcessor):
 
         df_ess.to_csv(f"{self.config.tmp_folder}/ess.csv", index=False)
 
-        DataProcessor.push_unique_count(
-            df_ess["siren"], Notification.notification_xcom_key, "unités légales"
+        DataProcessor.push_message(
+            Notification.notification_xcom_key,
+            column=df_ess["siren"],
+            description="unités légales",
         )
         del df_ess

--- a/workflows/data_pipelines/finess/processor.py
+++ b/workflows/data_pipelines/finess/processor.py
@@ -30,10 +30,10 @@ class FinessProcessor(DataProcessor):
         df_list_finess["liste_finess"] = df_list_finess["liste_finess"].astype(str)
         df_list_finess.to_csv(f"{self.config.tmp_folder}/finess.csv", index=False)
 
-        DataProcessor.push_unique_count(
-            df_list_finess["siret"],
+        DataProcessor.push_message(
             Notification.notification_xcom_key,
-            "établissements",
+            column=df_list_finess["siret"],
+            description="établissements",
         )
 
         del df_finess

--- a/workflows/data_pipelines/formation/processor.py
+++ b/workflows/data_pipelines/formation/processor.py
@@ -37,8 +37,9 @@ class FormationProcessor(DataProcessor):
         df_organisme_formation.to_csv(self.config.file_output, index=False)
         logging.info(f"Formation dataset saved in {self.config.file_output}")
 
-        DataProcessor.push_unique_count(
-            df_organisme_formation["siren"], Notification.notification_xcom_key, "siren"
+        DataProcessor.push_message(
+            Notification.notification_xcom_key,
+            column=df_organisme_formation["siren"],
         )
 
         del df_organisme_formation

--- a/workflows/data_pipelines/marche_inclusion/processor.py
+++ b/workflows/data_pipelines/marche_inclusion/processor.py
@@ -56,6 +56,7 @@ class MarcheInclusionProcessor(DataProcessor):
             index=False,
         )
 
-        DataProcessor.push_unique_count(
-            df_inclusion.siren, Notification.notification_xcom_key
+        DataProcessor.push_message(
+            Notification.notification_xcom_key,
+            column=df_inclusion.siret,
         )

--- a/workflows/data_pipelines/rge/processor.py
+++ b/workflows/data_pipelines/rge/processor.py
@@ -51,8 +51,10 @@ class RgeProcessor(DataProcessor):
         df_list_rge["liste_rge"] = df_list_rge["liste_rge"].astype(str)
 
         df_list_rge.to_csv(f"{self.config.tmp_folder}/rge.csv", index=False)
-        DataProcessor.push_unique_count(
-            df_list_rge["siret"], Notification.notification_xcom_key, "établissements"
+        DataProcessor.push_message(
+            Notification.notification_xcom_key,
+            column=df_list_rge["siret"],
+            description="établissements",
         )
 
         del df_rge

--- a/workflows/data_pipelines/sirene/flux/api.py
+++ b/workflows/data_pipelines/sirene/flux/api.py
@@ -19,15 +19,16 @@ class SireneApiClient(ApiClient):
         return self.fetch_all(
             endpoint=endpoint,
             response_and_pagination_handler=self.process_response_and_pagination,
-            batch_size=1000,
+            batch_size=1_000,
             sleep_time=2.0,
         )
 
     def fetch_data(self, endpoint: str, data_property: str) -> pd.DataFrame:
         """Fetch data from the INSEE API, flatten it, and return it as a DataFrame."""
         data = self.call_insee_api(endpoint, data_property)
-        # Process data in chunks to avoid memory issues
-        chunk_size = 100000
+        # Process data in big chunks to avoid out of memory errors while being efficient
+        chunk_size = 1_000_000
+        logging.info("Download finished. Flattening the content..")
 
         if data_property == "unitesLegales":
             flux = [
@@ -54,6 +55,7 @@ class SireneApiClient(ApiClient):
                 logging.info(
                     f"Processed chunk {i//chunk_size + 1} of {(len(data)-1)//chunk_size + 1}"
                 )
+            logging.info("Data has been flatten. Concatenating the chunks..")
 
             # Concatenate all chunks
             return pd.concat(dfs, ignore_index=True)

--- a/workflows/data_pipelines/sirene/flux/processor.py
+++ b/workflows/data_pipelines/sirene/flux/processor.py
@@ -47,8 +47,10 @@ class SireneFluxProcessor(DataProcessor):
         save_data_to_zipped_csv(
             df, self.config.tmp_folder, f"flux_unite_legale_{self.current_month}.csv"
         )
-        DataProcessor.push_unique_count(
-            df["siren"], Notification.notification_xcom_key, "unités légales"
+        DataProcessor.push_message(
+            Notification.notification_xcom_key,
+            column=df["siren"],
+            description="unités légales",
         )
 
     def get_current_flux_etablissement(self):
@@ -86,7 +88,7 @@ class SireneFluxProcessor(DataProcessor):
         save_data_to_zipped_csv(
             df, self.config.tmp_folder, f"flux_etablissement_{self.current_month}.csv"
         )
-        self.push_unique_count(
+        self.push_message(
             df["siret"], Notification.notification_xcom_key, "établissements"
         )
 

--- a/workflows/data_pipelines/sirene/flux/processor.py
+++ b/workflows/data_pipelines/sirene/flux/processor.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+import logging
+import os
 from dag_datalake_sirene.workflows.data_pipelines.sirene.flux.api import (
     SireneApiClient,
 )
@@ -7,7 +9,8 @@ from dag_datalake_sirene.workflows.data_pipelines.sirene.flux.config import (
     FLUX_SIRENE_CONFIG,
 )
 from dag_datalake_sirene.helpers.utils import (
-    save_data_to_zipped_csv,
+    get_dates_since_start_of_month,
+    zip_file,
 )
 from dag_datalake_sirene.helpers.minio_helpers import File
 
@@ -22,11 +25,18 @@ class SireneFluxProcessor(DataProcessor):
 
     def __init__(self):
         super().__init__(FLUX_SIRENE_CONFIG)
+        if not self.config.url_api:
+            raise ValueError("Sirene API flux URL is missing!")
+        if not self.config.auth_api:
+            raise ValueError("Sirene API flux token is missing!")
+
         self.client = SireneApiClient(self.config.url_api, self.config.auth_api)
         self.current_month = datetime.today().strftime("%Y-%m")
+        self.current_dates = get_dates_since_start_of_month()
 
-    def _construct_endpoint(self, base_endpoint: str, fields: str) -> str:
-        return base_endpoint.format(self.current_month, fields)
+    @staticmethod
+    def _construct_endpoint(base_endpoint: str, date: str, fields: str) -> str:
+        return base_endpoint.format(date, fields)
 
     def get_current_flux_unite_legale(self):
         fields = (
@@ -41,16 +51,34 @@ class SireneFluxProcessor(DataProcessor):
             "societeMissionUniteLegale,anneeCategorieEntreprise,anneeEffectifsUniteLegale,"
             "caractereEmployeurUniteLegale,nicSiegeUniteLegale"
         )
-
-        endpoint = self._construct_endpoint(self.BASE_UNITE_LEGALE_ENDPOINT, fields)
-        df = self.client.fetch_data(endpoint, "unitesLegales")
-        save_data_to_zipped_csv(
-            df, self.config.tmp_folder, f"flux_unite_legale_{self.current_month}.csv"
+        output_path = (
+            f"{self.config.tmp_folder}flux_unite_legale_{self.current_month}.csv"
         )
+        n_siren_processed = 0
+
+        for date in self.current_dates:
+            logging.info(f"{date} -- processing..")
+            endpoint = self._construct_endpoint(
+                self.BASE_UNITE_LEGALE_ENDPOINT, date, fields
+            )
+            df = self.client.fetch_data(endpoint, "unitesLegales")
+
+            # Create a header for the first dump, append afterward
+            file_exists = os.path.isfile(output_path)
+            df.to_csv(output_path, mode="a", header=(not file_exists), index=False)
+
+            n_siren = df["siren"].nunique()
+            logging.info(f"{date} -- processed: {n_siren} siren")
+            n_siren_processed += n_siren
+            del df
+
+        logging.info(f"CSV output ready with {n_siren_processed} siren")
+        zip_file(output_path)
+        logging.info("File zipped. Done!")
+
         DataProcessor.push_message(
             Notification.notification_xcom_key,
-            column=df["siren"],
-            description="unités légales",
+            description=f"{n_siren_processed} siren",
         )
 
     def get_current_flux_etablissement(self):
@@ -77,19 +105,38 @@ class SireneFluxProcessor(DataProcessor):
             "coordonneeLambertAbscisseEtablissement,"
             "coordonneeLambertOrdonneeEtablissement"
         )
-
-        endpoint = self._construct_endpoint(self.BASE_ETABLISSEMENT_ENDPOINT, fields)
-
-        df = self.client.fetch_data(endpoint, "etablissements")
-        for prefix in ["adresseEtablissement_", "adresse2Etablissement_"]:
-            df.columns = [
-                col.replace(prefix, "") if prefix in col else col for col in df.columns
-            ]
-        save_data_to_zipped_csv(
-            df, self.config.tmp_folder, f"flux_etablissement_{self.current_month}.csv"
+        output_path = (
+            f"{self.config.tmp_folder}flux_etablissement_{self.current_month}.csv"
         )
-        self.push_message(
-            df["siret"], Notification.notification_xcom_key, "établissements"
+        n_siret_processed = 0
+
+        for date in self.current_dates:
+            logging.info(f"{date} -- processing..")
+            endpoint = self._construct_endpoint(
+                self.BASE_ETABLISSEMENT_ENDPOINT, date, fields
+            )
+            df = self.client.fetch_data(endpoint, "etablissements")
+            for prefix in ["adresseEtablissement_", "adresse2Etablissement_"]:
+                df.columns = [
+                    col.replace(prefix, "") if prefix in col else col
+                    for col in df.columns
+                ]
+            # Create a header for the first dump, append afterward
+            file_exists = os.path.isfile(output_path)
+            df.to_csv(output_path, mode="a", header=(not file_exists), index=False)
+
+            n_siret = df["siret"].nunique()
+            logging.info(f"{date} -- processed: {n_siret} siret")
+            n_siret_processed += n_siret
+            del df
+
+        logging.info(f"CSV output ready with {n_siret_processed} siret")
+        zip_file(output_path)
+        logging.info("File zipped. Done!")
+
+        DataProcessor.push_message(
+            Notification.notification_xcom_key,
+            description=f"{n_siret_processed} siret",
         )
 
     def send_flux_to_minio(self):
@@ -100,18 +147,21 @@ class SireneFluxProcessor(DataProcessor):
                     source_name=f"flux_unite_legale_{self.current_month}.csv.gz",
                     dest_path=self.config.minio_path,
                     dest_name=f"flux_unite_legale_{self.current_month}.csv.gz",
+                    content_type=None,
                 ),
                 File(
                     source_path=self.config.tmp_folder,
                     source_name=f"flux_etablissement_{self.current_month}.csv.gz",
                     dest_path=self.config.minio_path,
                     dest_name=f"flux_etablissement_{self.current_month}.csv.gz",
+                    content_type=None,
                 ),
                 File(
                     source_path=self.config.tmp_folder,
                     source_name="metadata.json",
                     dest_path=self.config.minio_path,
                     dest_name="metadata.json",
+                    content_type=None,
                 ),
             ],
         )

--- a/workflows/data_pipelines/spectacle/processor.py
+++ b/workflows/data_pipelines/spectacle/processor.py
@@ -45,8 +45,10 @@ class SpectacleProcessor(DataProcessor):
             ["siren", "statut_entrepreneur_spectacle", "est_entrepreneur_spectacle"]
         ].to_csv(self.config.file_output, index=False)
 
-        self.push_unique_count(
-            df_spectacle["siren"], Notification.notification_xcom_key, "unités légales"
+        self.push_message(
+            Notification.notification_xcom_key,
+            column=df_spectacle["siren"],
+            description="unités légales",
         )
 
         del df_spectacle

--- a/workflows/data_pipelines/uai/processor.py
+++ b/workflows/data_pipelines/uai/processor.py
@@ -115,6 +115,17 @@ class UaiProcessor(DataProcessor):
         )
         annuaire_uai.to_csv(self.config.file_output, index=False)
 
-        self.push_unique_count(
-            annuaire_uai["siret"], Notification.notification_xcom_key
+        self.push_message(
+            Notification.notification_xcom_key,
+            column=annuaire_uai["uai"],
+            description="UAI",
         )
+        self.push_message(
+            Notification.notification_xcom_key,
+            column=annuaire_uai["siret"],
+            description="siret",
+        )
+
+        del df_onisep
+        del df_menj
+        del df_mesr


### PR DESCRIPTION
The Sirene API is doing a lot of API calls. 

Our current code can't scale enough so the tasks are failing due to too much RAM usage.

This PR proposes a fix so we only save in the RAM one day of updates at a time instead of all the days since the begining of the month.

The `DataProcessor.push_unique_count()` has been refactored to `DataProcessor.push_message()` to allow sending messages without having the whole column to count still in memory.