### PR TITLE
[BUG]fix: update e2e test in indexing workflow

### DIFF
--- a/tests/e2e_tests/test_api.py
+++ b/tests/e2e_tests/test_api.py
@@ -106,7 +106,7 @@ def test_organisme_formation(api_response_tester):
     api_response_tester.test_max_number_of_results(path, 0)
     path = "/search?q=196716856"
     api_response_tester.test_field_value(path, 0, "complements.est_qualiopi", True)
-    path = "/search?q=552120222"
+    path = "/search?q=775701477"
     api_response_tester.test_field_value(path, 0, "complements.est_qualiopi", False)
     api_response_tester.test_field_value(
         path, 0, "complements.est_organisme_formation", True


### PR DESCRIPTION
Indexing workflow fail because `societe generale` is no longer `organisme formation`.