### PR TITLE
chore(tests): Remove fail-fast option (-x) from pytest execution

### DIFF
--- a/tests/e2e_tests/run_tests.py
+++ b/tests/e2e_tests/run_tests.py
@@ -2,6 +2,6 @@ import pytest
 
 
 def run_e2e_tests():
-    exit_code = pytest.main(["-x", "dags/dag_datalake_sirene/tests/e2e_tests", "-vv"])
+    exit_code = pytest.main(["dags/dag_datalake_sirene/tests/e2e_tests", "-vv"])
     if exit_code > 0:
         raise RuntimeError("Pytest Fail!!!!!")


### PR DESCRIPTION
Removed the `-x` flag from pytest, allowing all end-to-end API tests for Elasticsearch indexing to run instead of stopping at the first failure.
Ensures a complete test report is generated, improving debugging and test coverage visibility.