### PR TITLE
[BUG][SIRENE.FLUX] Handle siren.t with multiple updates

### DIFF
--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -530,7 +530,10 @@ def download_file(download_url: str, destination_path: str) -> None:
     logging.info(f"..download successful! File located in {destination_path}.")
 
 
-def get_dates_since_start_of_month(include_today: bool = True) -> list[str]:
+def get_dates_since_start_of_month(
+    include_today: bool = True,
+    ascending: bool = True,
+) -> list[str]:
     """
     Get the dates since the beginning of the month until today.
 
@@ -552,5 +555,7 @@ def get_dates_since_start_of_month(include_today: bool = True) -> list[str]:
     while day <= last_day_of_month:
         dates.append(day.strftime("%Y-%m-%d"))
         day += timedelta(days=1)
+
+    dates.sort(reverse=(not ascending))
 
     return dates


### PR DESCRIPTION
✅ Ran successfully on dev-01.


> Il faut garder que la dernière version d'un row dans le retour de l'API
par exemple si siret_X a changé le 01-02-2025 et le 15-02-2025 dans ton code t'auras les deux lignes dans le csv
alors que que quand on appelait par mois, si par défaut la dernière mise à jour qui est incluse dans la réponse
c'est un peu comme ce que je fais dans le RNE, il faut écraser les anciennes mises à jour.

😄 