### PR TITLE
[BUG][ETL][FLUX.SIRENE] minio path

### DIFF
--- a/workflows/data_pipelines/sirene/flux/config.py
+++ b/workflows/data_pipelines/sirene/flux/config.py
@@ -9,8 +9,8 @@ FLUX_SIRENE_CONFIG = DataSourceConfig(
     name="flux_api_sirene",
     tmp_folder=f"{DataSourceConfig.base_tmp_folder}/sirene/flux/",
     minio_path="insee/flux/",
-    url_minio=f"{MINIO_BASE_URL}insee/flux/latest/",
-    url_minio_metadata=f"{MINIO_BASE_URL}insee/flux/latest/metadata.json",
+    url_minio=f"{MINIO_BASE_URL}insee/flux/",
+    url_minio_metadata=f"{MINIO_BASE_URL}insee/flux/metadata.json",
     url_api="https://api.insee.fr/api-sirene/3.11/",
     auth_api=Variable.get("SECRET_BEARER_INSEE", None),
 )


### PR DESCRIPTION
The metadata.json file from the Sirene flux was missing.