### PR TITLE
[ALIM'CONFIANCE] Add alim'confiance to ES index

### DIFF
--- a/tests/e2e_tests/test_api.py
+++ b/tests/e2e_tests/test_api.py
@@ -278,6 +278,22 @@ def test_achats_responsables(api_response_tester):
     )
 
 
+def test_alim_confiance(api_response_tester):
+    path = "/search?est_alim_confiance=true"
+    api_response_tester.test_field_value(
+        path, 0, "complements.est_alim_confiance", True
+    )
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
+
+    path = "/search?est_alim_confiance=false"
+    api_response_tester.test_number_of_results(path, min_total_results_filters)
+
+    path = "/search?q=343262622"  # LIDL
+    api_response_tester.test_field_value(
+        path, 0, "complements.est_alim_confiance", True
+    )
+
+
 def test_est_association(api_response_tester):
     path = "/search?est_association=True"
     response = api_response_tester.get_api_response(path)

--- a/workflows/data_pipelines/alim_confiance/README.md
+++ b/workflows/data_pipelines/alim_confiance/README.md
@@ -1,0 +1,11 @@
+# Documentation
+
+## data_processing_alim_confiance
+
+| Information | Valeur |
+| -------- | -------- |
+| Fichier source | `dag.py` |
+| Description | Ce traitement permet de récupérer la liste des entreprises dont au moins un établissement a eu un contrôle sanitaire |
+| Fréquence | Quotidienne |
+| Données sources | [Alim'Confiance](https://www.data.gouv.fr/fr/datasets/resultats-des-controles-officiels-sanitaires-dispositif-dinformation-alimconfiance/#/resources/fff0cc27-977b-40d5-9c11-f7e4e79a0b72) |
+| Données de sorties | Minio |

--- a/workflows/data_pipelines/alim_confiance/config.py
+++ b/workflows/data_pipelines/alim_confiance/config.py
@@ -1,0 +1,31 @@
+from dag_datalake_sirene.config import (
+    DATA_GOUV_BASE_URL,
+    MINIO_BASE_URL,
+    DataSourceConfig,
+)
+
+ALIM_CONFIANCE_CONFIG = DataSourceConfig(
+    name="alim_confiance",
+    tmp_folder=f"{DataSourceConfig.base_tmp_folder}/alim_confiance",
+    minio_path="alim_confiance",
+    file_name="alim_confiance",
+    files_to_download={
+        "alim_confiance": {
+            "url": f"{DATA_GOUV_BASE_URL}fff0cc27-977b-40d5-9c11-f7e4e79a0b72",
+            "resource_id": "fff0cc27-977b-40d5-9c11-f7e4e79a0b72",
+            "destination": f"{DataSourceConfig.base_tmp_folder}/alim_confiance/alim-confiance-download.csv",
+        },
+    },
+    url_minio=f"{MINIO_BASE_URL}alim_confiance/latest/alim_confiance.csv",
+    url_minio_metadata=f"{MINIO_BASE_URL}alim_confiance/latest/metadata.json",
+    file_output=f"{DataSourceConfig.base_tmp_folder}/alim_confiance/alim_confiance.csv",
+    table_ddl="""
+        BEGIN;
+        CREATE TABLE IF NOT EXISTS alim_confiance
+        (
+            siren PRIMARY KEY,
+            est_alim_confiance INTEGER
+        );
+        COMMIT;
+    """,
+)

--- a/workflows/data_pipelines/alim_confiance/dag.py
+++ b/workflows/data_pipelines/alim_confiance/dag.py
@@ -1,0 +1,74 @@
+from datetime import timedelta
+
+from airflow.decorators import dag, task
+from airflow.utils.dates import days_ago
+
+from dag_datalake_sirene.config import EMAIL_LIST
+from dag_datalake_sirene.helpers import Notification
+from dag_datalake_sirene.workflows.data_pipelines.alim_confiance.processor import (
+    AlimConfianceProcessor,
+)
+
+default_args = {
+    "depends_on_past": False,
+    "email_on_failure": True,
+    "email_on_retry": False,
+    "email": EMAIL_LIST,
+    "retries": 1,
+}
+
+
+@dag(
+    tags=["alim_confiance", "label"],
+    default_args=default_args,
+    schedule_interval="0 16 * * *",
+    start_date=days_ago(8),
+    dagrun_timeout=timedelta(minutes=60 * 5),
+    params={},
+    catchup=False,
+    on_failure_callback=Notification.send_notification_mattermost,
+    on_success_callback=Notification.send_notification_mattermost,
+)
+def data_processing_alim_confiance():
+    alim_confiance_processor = AlimConfianceProcessor()
+
+    @task.bash
+    def clean_previous_outputs():
+        return f"rm -rf {alim_confiance_processor.config.tmp_folder} && mkdir -p {alim_confiance_processor.config.tmp_folder}"
+
+    @task
+    def download_data():
+        return alim_confiance_processor.download_data()
+
+    @task
+    def preprocess_data():
+        return alim_confiance_processor.preprocess_data()
+
+    @task
+    def save_date_last_modified():
+        return alim_confiance_processor.save_date_last_modified()
+
+    @task
+    def send_file_to_minio():
+        return alim_confiance_processor.send_file_to_minio()
+
+    @task
+    def compare_files_minio():
+        return alim_confiance_processor.compare_files_minio()
+
+    @task.bash
+    def clean_up():
+        return f"rm -rf {alim_confiance_processor.config.tmp_folder}"
+
+    (
+        clean_previous_outputs()
+        >> download_data()
+        >> preprocess_data()
+        >> save_date_last_modified()
+        >> send_file_to_minio()
+        >> compare_files_minio()
+        >> clean_up()
+    )
+
+
+data_processing_alim_confiance()

--- a/workflows/data_pipelines/alim_confiance/processor.py
+++ b/workflows/data_pipelines/alim_confiance/processor.py
@@ -1,0 +1,40 @@
+import pandas as pd
+
+from dag_datalake_sirene.helpers import DataProcessor, Notification
+from dag_datalake_sirene.workflows.data_pipelines.alim_confiance.config import (
+    ALIM_CONFIANCE_CONFIG,
+)
+
+
+class AlimConfianceProcessor(DataProcessor):
+    def __init__(self):
+        super().__init__(ALIM_CONFIANCE_CONFIG)
+
+    def preprocess_data(self):
+        df_alim = (
+            pd.read_csv(
+                self.config.files_to_download["alim_confiance"]["destination"],
+                dtype="string",
+                sep=";",
+                usecols=["SIRET"],
+            )
+            .assign(
+                est_alim_confiance=1,
+                siren=lambda df: df["SIRET"].str.replace(" ", "").str[:9].str.zfill(9),
+            )
+            .loc[
+                lambda x: x["siren"].notna() & x["siren"].str.isdigit(),
+                ["siren", "est_alim_confiance"],
+            ]
+            .query("siren != ''")
+            .drop_duplicates(subset=["siren"])
+        )
+
+        df_alim.to_csv(self.config.file_output, index=False)
+
+        DataProcessor.push_message(
+            Notification.notification_xcom_key,
+            column=df_alim.siren,
+        )
+
+        del df_alim

--- a/workflows/data_pipelines/data_gouv/processor.py
+++ b/workflows/data_pipelines/data_gouv/processor.py
@@ -57,6 +57,7 @@ class DataGouvProcessor:
             "date_mise_a_jour_rne",
             "egapro_renseignee",
             "est_achats_responsables",
+            "est_alim_confiance",
             "est_association",
             "est_entrepreneur_individuel",
             "est_entrepreneur_spectacle",
@@ -168,6 +169,9 @@ class DataGouvProcessor:
             sqlite_str_to_bool
         )
         chunk["est_achats_responsables"] = chunk["est_achats_responsables"].apply(
+            sqlite_str_to_bool
+        )
+        chunk["est_alim_confiance"] = chunk["est_alim_confiance"].apply(
             sqlite_str_to_bool
         )
         chunk["est_patrimoine_vivant"] = chunk["est_patrimoine_vivant"].apply(

--- a/workflows/data_pipelines/data_gouv/queries.py
+++ b/workflows/data_pipelines/data_gouv/queries.py
@@ -57,6 +57,11 @@ SELECT ul.etat_administratif_unite_legale as etat_administratif,
         WHERE siren = ul.siren
     ) as est_achats_responsables,
     (
+        SELECT est_alim_confiance
+        FROM est_alim_confiance
+        WHERE siren = ul.siren
+    ) as est_alim_confiance,
+    (
         SELECT est_patrimoine_vivant
         FROM patrimoine_vivant
         WHERE siren = ul.siren

--- a/workflows/data_pipelines/data_gouv/queries.py
+++ b/workflows/data_pipelines/data_gouv/queries.py
@@ -58,7 +58,7 @@ SELECT ul.etat_administratif_unite_legale as etat_administratif,
     ) as est_achats_responsables,
     (
         SELECT est_alim_confiance
-        FROM est_alim_confiance
+        FROM alim_confiance
         WHERE siren = ul.siren
     ) as est_alim_confiance,
     (

--- a/workflows/data_pipelines/elasticsearch/mapping_index.py
+++ b/workflows/data_pipelines/elasticsearch/mapping_index.py
@@ -323,6 +323,7 @@ class UniteLegaleMapping(InnerDoc):
     est_entrepreneur_spectacle = Boolean()
     egapro_renseignee = Boolean()
     est_achats_responsables = Boolean()
+    est_alim_confiance = Boolean()
     est_association = Boolean()
     est_finess = Boolean()
     est_bio = Boolean()

--- a/workflows/data_pipelines/elasticsearch/process_unites_legales.py
+++ b/workflows/data_pipelines/elasticsearch/process_unites_legales.py
@@ -180,6 +180,11 @@ def process_unites_legales(chunk_unites_legales_sqlite):
             unite_legale["est_achats_responsables"]
         )
 
+        # Alim'Confiance
+        unite_legale_processed["est_alim_confiance"] = sqlite_str_to_bool(
+            unite_legale["est_alim_confiance"]
+        )
+
         # Marche Inclusion
         unite_legale_processed["est_siae"] = sqlite_str_to_bool(
             unite_legale["est_siae"]

--- a/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
+++ b/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
@@ -379,6 +379,8 @@ select_fields_to_index_query = """SELECT
              egapro_renseignee,
             (SELECT est_achats_responsables FROM achats_responsables WHERE siren = ul.siren) as
              est_achats_responsables,
+            (SELECT est_alim_confiance FROM est_alim_confiance WHERE siren = ul.siren) as
+             est_alim_confiance,
             (SELECT est_patrimoine_vivant FROM patrimoine_vivant WHERE siren = ul.siren) as
              est_patrimoine_vivant,
             (SELECT DISTINCT colter_code_insee FROM colter WHERE siren = ul.siren) as

--- a/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
+++ b/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
@@ -379,7 +379,7 @@ select_fields_to_index_query = """SELECT
              egapro_renseignee,
             (SELECT est_achats_responsables FROM achats_responsables WHERE siren = ul.siren) as
              est_achats_responsables,
-            (SELECT est_alim_confiance FROM est_alim_confiance WHERE siren = ul.siren) as
+            (SELECT est_alim_confiance FROM alim_confiance WHERE siren = ul.siren) as
              est_alim_confiance,
             (SELECT est_patrimoine_vivant FROM patrimoine_vivant WHERE siren = ul.siren) as
              est_patrimoine_vivant,

--- a/workflows/data_pipelines/etl/dag.py
+++ b/workflows/data_pipelines/etl/dag.py
@@ -19,6 +19,9 @@ from dag_datalake_sirene.workflows.data_pipelines.achats_responsables.config imp
 from dag_datalake_sirene.workflows.data_pipelines.agence_bio.config import (
     AGENCE_BIO_CONFIG,
 )
+from dag_datalake_sirene.workflows.data_pipelines.alim_confiance.config import (
+    ALIM_CONFIANCE_CONFIG,
+)
 from dag_datalake_sirene.workflows.data_pipelines.bilans_financiers.config import (
     BILANS_FINANCIERS_CONFIG,
 )
@@ -331,6 +334,7 @@ def database_constructor():
         MARCHE_INCLUSION_CONFIG,
         ACHATS_RESPONSABLES_CONFIG,
         PATRIMOINE_VIVANT_CONFIG,
+        ALIM_CONFIANCE_CONFIG,
     ]
     tasks = []
     for config in config_list:

--- a/workflows/data_pipelines/etl/task_functions/create_json_last_modified.py
+++ b/workflows/data_pipelines/etl/task_functions/create_json_last_modified.py
@@ -16,6 +16,9 @@ from dag_datalake_sirene.workflows.data_pipelines.achats_responsables.config imp
 from dag_datalake_sirene.workflows.data_pipelines.agence_bio.config import (
     AGENCE_BIO_CONFIG,
 )
+from dag_datalake_sirene.workflows.data_pipelines.alim_confiance.config import (
+    ALIM_CONFIANCE_CONFIG,
+)
 from dag_datalake_sirene.workflows.data_pipelines.bilans_financiers.config import (
     BILANS_FINANCIERS_CONFIG,
 )
@@ -74,6 +77,7 @@ def create_data_source_last_modified_file(**kwargs):
         MARCHE_INCLUSION_CONFIG.url_minio_metadata: "marche_inclusion",
         ACHATS_RESPONSABLES_CONFIG.url_minio_metadata: "achats_responsables",
         PATRIMOINE_VIVANT_CONFIG.url_minio_metadata: "patrimoine_vivant",
+        ALIM_CONFIANCE_CONFIG.url_minio_metadata: "alim_confiance",
     }
 
     json_file_path = os.path.join(


### PR DESCRIPTION
Related to https://github.com/annuaire-entreprises-data-gouv-fr/search-api/issues/510

The dataset is not available at the moment on datagouv. The DAG should be activated only once it is available again.
In the meantime a locally created output has been uploaded to MinIO so the ETL DAG and API can already run as expected.