### PR TITLE
[BUG][ELASTIC SNAPSHOT] Fix timeout issue

### DIFF
--- a/workflows/data_pipelines/elasticsearch/task_functions/snapshot.py
+++ b/workflows/data_pipelines/elasticsearch/task_functions/snapshot.py
@@ -174,6 +174,7 @@ def delete_old_snapshots(**kwargs):
         hosts=[ELASTIC_URL],
         http_auth=(ELASTIC_USER, ELASTIC_PASSWORD),
         retry_on_timeout=True,
+        timeout=60,
     )
 
     elastic_connection = connections.get_connection()


### PR DESCRIPTION
Related to https://github.com/annuaire-entreprises-data-gouv-fr/search-infra/issues/503

It has been a bit painful to test but it seems that this simple fix is working. The failure was due to a default timeout set at 10s. Increasing it to 60s for that particular request did the trick.

Now:
```
[2025-05-18, 09:39:29 CEST] {snapshot.py:194} INFO - Deleting snapshot siren-20250512074927 from data-staging
[2025-05-18, 09:39:44 CEST] {base.py:265} INFO - DELETE https://elastic.staging.recherche-entreprises.infra.api.gouv.fr:9200/_snapshot/data-staging/siren-20250512074927 [status:200 request:14.243s]
[2025-05-18, 09:39:44 CEST] {python.py:237} INFO - Done. Returned value was: None
```

Before:
```
[2025-05-19, 09:43:22 CEST] {base.py:288} WARNING - DELETE https://elastic.recherche-entreprises.infra.api.gouv.fr:9200/_snapshot/data-prod/siren-20250513074324 [status:N/A request:10.011s]
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.12/site-packages/urllib3/connectionpool.py", line 468, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/home/airflow/.local/lib/python3.12/site-packages/urllib3/connectionpool.py", line 463, in _make_request
    httplib_response = conn.getresponse()
                       ^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/sentry_sdk/integrations/stdlib.py", line 131, in getresponse
    rv = real_getresponse(self, *args, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/http/client.py", line 1428, in getresponse
    response.begin()
  File "/usr/local/lib/python3.12/http/client.py", line 331, in begin
    version, status, reason = self._read_status()
                              ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/http/client.py", line 292, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/socket.py", line 708, in readinto
    return self._sock.recv_into(b)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/ssl.py", line 1252, in recv_into
    return self.read(nbytes, buffer)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/ssl.py", line 1104, in read
    return self._sslobj.read(len, buffer)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TimeoutError: The read operation timed out
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.12/site-packages/elasticsearch/connection/http_urllib3.py", line 255, in perform_request
    response = self.pool.urlopen(
               ^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/urllib3/connectionpool.py", line 802, in urlopen
    retries = retries.increment(
              ^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/urllib3/util/retry.py", line 527, in increment
    raise six.reraise(type(error), error, _stacktrace)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/urllib3/packages/six.py", line 770, in reraise
    raise value
  File "/home/airflow/.local/lib/python3.12/site-packages/urllib3/connectionpool.py", line 716, in urlopen
    httplib_response = self._make_request(
                       ^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/urllib3/connectionpool.py", line 470, in _make_request
    self._raise_timeout(err=e, url=url, timeout_value=read_timeout)
  File "/home/airflow/.local/lib/python3.12/site-packages/urllib3/connectionpool.py", line 358, in _raise_timeout
    raise ReadTimeoutError(
urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='elastic.recherche-entreprises.infra.api.gouv.fr', port=9200): Read timed out. (read timeout=10)
```