### PR TITLE
[RNE]fix: don't use statut diffusion insee from rne

### DIFF
--- a/workflows/data_pipelines/etl/sqlite/queries/unite_legale.py
+++ b/workflows/data_pipelines/etl/sqlite/queries/unite_legale.py
@@ -159,7 +159,7 @@ insert_remaining_rne_data_into_main_table_query = """
                 nature_juridique AS nature_juridique_unite_legale,
                 activite_principale AS activite_principale_unite_legale,
                 NULL AS economie_sociale_solidaire_unite_legale,
-                statut_diffusion AS statut_diffusion_unite_legale,
+                NULL AS statut_diffusion_unite_legale,
                 NULL AS est_societe_mission,
                 NULL AS annee_categorie_entreprise,
                 NULL AS annee_tranche_effectif_salarie,


### PR DESCRIPTION
related to https://github.com/annuaire-entreprises-data-gouv-fr/site/issues/1767
The SIREN 000.000.000 is currently displayed as non-diffusible on the website because we have been using the RNE data to determine the statut when the Sirene data is missing. However, since this appears to be an error on the Inpi side, we will now rely exclusively on the Sirene data for this field, whenever it is available.