### PR TITLE
[NonDiffusible]Show nom raison sociale is ND is a personne morale according Insee

### DIFF
--- a/workflows/data_pipelines/data_gouv/processor.py
+++ b/workflows/data_pipelines/data_gouv/processor.py
@@ -32,6 +32,7 @@ from dag_datalake_sirene.workflows.data_pipelines.elasticsearch.data_enrichment 
     is_association,
     is_entrepreneur_individuel,
     is_ess,
+    is_personne_morale_insee,
     is_service_public,
 )
 
@@ -137,7 +138,14 @@ class DataGouvProcessor:
         chunk["colter_elus"] = chunk["colter_elus"].apply(json.loads)
         chunk["nom_complet"] = chunk.apply(
             lambda row: format_nom_complet(
-                row["nom"], row["nom_usage"], row["nom_raison_sociale"], row["prenom"]
+                row["nom"],
+                row["nom_usage"],
+                row["prenom"],
+                row["nom_raison_sociale"],
+                is_personne_morale_insee=is_personne_morale_insee(
+                    row["nature_juridique"]
+                ),
+                is_non_diffusible=row["statut_diffusion"] != "O",
             ),
             axis=1,
         )

--- a/workflows/data_pipelines/elasticsearch/data_enrichment.py
+++ b/workflows/data_pipelines/elasticsearch/data_enrichment.py
@@ -40,9 +40,20 @@ excluded_nature_juridique_L100_3 = set(
 def format_nom_complet(
     nom=None,
     nom_usage=None,
-    nom_raison_sociale=None,
     prenom=None,
+    nom_raison_sociale=None,
+    est_personne_morale_insee: bool = False,
+    is_non_diffusible: bool = False,
 ):
+    """Build `nom_complet` from identity parts.
+
+    If `est_personne_morale_insee` is True, only keep `nom_raison_sociale` when present.
+    """
+    # Personne morale and non diffusible: keep only raison sociale when available
+    # (to avoid having [ND] mentions in nom_complet in non diffusible companies)
+    if est_personne_morale_insee and is_non_diffusible and nom_raison_sociale:
+        return nom_raison_sociale.upper().strip()
+
     name = None
     if prenom or nom or nom_usage:
         if nom_usage:
@@ -143,6 +154,19 @@ def is_entrepreneur_individuel(nature_juridique_unite_legale):
         return True
     else:
         return False
+
+
+def is_personne_morale_insee(nature_juridique_unite_legale):
+    """Return True if INSEE legal nature indicates personne morale.
+
+    Rules (personne physique are codes 1000 and  les unités non dotées de la personnalité morale start with '2') https://www.insee.fr/fr/information/7456564:
+    - Return False for personne physique and les unités non dotées de la personnalité morale
+    - Return True otherwise
+    """
+    if nature_juridique_unite_legale is None:
+        return True
+    nature = str(nature_juridique_unite_legale)
+    return not (nature == "1000" or nature.startswith("2"))
 
 
 # ESS

--- a/workflows/data_pipelines/elasticsearch/mapping_index.py
+++ b/workflows/data_pipelines/elasticsearch/mapping_index.py
@@ -337,6 +337,7 @@ class UniteLegaleMapping(InnerDoc):
     est_rge = Boolean()
     est_service_public = Boolean()
     est_siae = Boolean()
+    est_personne_morale_insee = Boolean()
     est_societe_mission = Keyword()
     est_uai = Boolean()
     etablissements = Nested(EtablissementMapping)

--- a/workflows/data_pipelines/elasticsearch/process_unites_legales.py
+++ b/workflows/data_pipelines/elasticsearch/process_unites_legales.py
@@ -21,6 +21,7 @@ from dag_datalake_sirene.workflows.data_pipelines.elasticsearch.data_enrichment 
     is_association,
     is_entrepreneur_individuel,
     is_ess,
+    is_personne_morale_insee,
     is_service_public,
     label_section_from_activite,
     map_categorie_to_number,
@@ -45,8 +46,12 @@ def process_unites_legales(chunk_unites_legales_sqlite):
         unite_legale_processed["nom_complet"] = format_nom_complet(
             unite_legale["nom"],
             unite_legale["nom_usage"],
-            unite_legale["nom_raison_sociale"],
             unite_legale["prenom"],
+            unite_legale["nom_raison_sociale"],
+            est_personne_morale_insee=is_personne_morale_insee(
+                unite_legale["nature_juridique_unite_legale"]
+            ),
+            is_non_diffusible=is_non_diffusible,
         )
 
         # Replace missing values with 0
@@ -74,6 +79,11 @@ def process_unites_legales(chunk_unites_legales_sqlite):
         # Entrepreneur individuel
         unite_legale_processed["est_entrepreneur_individuel"] = (
             is_entrepreneur_individuel(unite_legale["nature_juridique_unite_legale"])
+        )
+
+        # Personne morale (INSEE)
+        unite_legale_processed["est_personne_morale_insee"] = is_personne_morale_insee(
+            unite_legale["nature_juridique_unite_legale"]
         )
 
         # Categorie entreprise


### PR DESCRIPTION

Cette PR introduit une nouvelle variable **is_personne_morale**, définie comme suit :
`is_personne_morale = not personne_physique and not unités non dotées de la personnalité morale`
Concrètement, cela correspond aux **formes juridiques ≠ 1000** et **ne commençant pas par "2"**.

Par ailleurs, si une **unité légale** est **non diffusible** (`statut_diffusion = P`) **et** est une **personne morale** (`is_personne_morale = true`), alors le champ **nom_complet** passe de `"ND"` à la **raison sociale** (**nom_raison_sociale**).

Plus de détails ici : [[#1889 sur GitHub](https://github.com/annuaire-entreprises-data-gouv-fr/site/issues/1889)](https://github.com/annuaire-entreprises-data-gouv-fr/site/issues/1889)
Référence INSEE : [https://www.insee.fr/fr/information/7456564](https://www.insee.fr/fr/information/7456564)
