### PR TITLE
fix(ess_france): use sqlite bool instead of Python bool in ess france table

### DIFF
--- a/workflows/data_pipelines/ess_france/processor.py
+++ b/workflows/data_pipelines/ess_france/processor.py
@@ -12,7 +12,7 @@ class EssFranceProcessor(DataProcessor):
         df_ess = pd.read_csv(self.config.files_to_download["ess"]["url"], dtype=str)
         df_ess["SIREN"] = df_ess["SIREN"].str.zfill(9)
         df_ess.rename(columns={"SIREN": "siren"}, inplace=True)
-        df_ess["est_ess_france"] = True
+        df_ess["est_ess_france"] = 1
         df_ess = df_ess[["siren", "est_ess_france"]]
 
         df_ess.to_csv(f"{self.config.tmp_folder}/ess.csv", index=False)


### PR DESCRIPTION
The Python boolean is stored as a string by SQLite, and when it’s read back into Python it remains a string rather than being converted back to a boolean.