### PR TITLE
fix(sirene.flux): temporary exclude of 2025-12-06 & 07

### DIFF
--- a/workflows/data_pipelines/sirene/flux/processor.py
+++ b/workflows/data_pipelines/sirene/flux/processor.py
@@ -39,6 +39,13 @@ class SireneFluxProcessor(DataProcessor):
         self.current_dates = get_dates_since_start_of_month(
             include_today=False, ascending=False
         )
+        # 2025-12-10 HOTFIX TO REVERT AT ANYTIME IN 2026
+        # Sirene Flux API is returning 404 for the following days:
+        # 2025-12-06 and 2025-12-07
+        problematic_dates = ["2025-12-06", "2025-12-07"]
+        self.current_dates = [
+            date for date in self.current_dates if date not in problematic_dates
+        ]
 
     @staticmethod
     def _construct_endpoint(base_endpoint: str, date: str, fields: str) -> str:


### PR DESCRIPTION
Closes #624 

Tested on local env ✅ [Output](https://console.object.files.data.gouv.fr/browser/opendata/ae%2Fdev%2Finsee%2Fflux%2F).

<img width="1010" height="375" alt="image" src="https://github.com/user-attachments/assets/98c167ff-358a-42ed-831b-ac758ae84506" />
