### PR TITLE
fix(rne): remove db file only after zip is sent to MinIO

### DIFF
--- a/workflows/data_pipelines/rne/database/task_functions.py
+++ b/workflows/data_pipelines/rne/database/task_functions.py
@@ -333,8 +333,6 @@ def upload_db_to_minio(**kwargs):
         with gzip.open(database_zip_file_path, "wb") as f_out:
             shutil.copyfileobj(f_in, f_out)
 
-    os.remove(database_file_path)
-
     logging.info(f"Sending database: rne_{start_date}.db.gz")
     send_to_minio(
         [
@@ -346,7 +344,9 @@ def upload_db_to_minio(**kwargs):
             }
         ]
     )
-    # Delete the local file after uploading to Minio
+
+    # Delete local files after uploading to Minio
+    os.remove(database_file_path)
     if os.path.exists(database_zip_file_path):
         os.remove(database_zip_file_path)
     else:


### PR DESCRIPTION
When the `upload_db_to_minio` task is retried, the database file is no longer available locally because it was removed during the first attempt. As a result, the retry fails when it reaches the zipping step. This PR changes the behaviour so that the database file is only removed after the zip has been successfully sent to MinIO.