### PR TITLE
feat(flux): run sirene dag at 6:30 am instead of 5

### DIFF
--- a/workflows/data_pipelines/sirene/flux/dag.py
+++ b/workflows/data_pipelines/sirene/flux/dag.py
@@ -24,7 +24,7 @@ default_args = {
 @dag(
     tags=["sirene", "flux"],
     default_args=default_args,
-    schedule_interval="0 4 * * *",  # Daily at 4 AM
+    schedule_interval="30 6 * * *",  # Daily at 6:30 AM
     start_date=datetime(2025, 8, 20),  # more naive than days_ago()
     dagrun_timeout=timedelta(minutes=60 * 12),
     params={},


### PR DESCRIPTION
Recent runs show that the updates usually take place between 7:00 and 8:00 a.m. As a result, the DAG runs for about three hours with retries. This update delays the execution slightly to avoid unnecessary API calls.