### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    cooldown:
+      semver-major-days: 5
+      semver-minor-days: 3
+      semver-patch-days: 1
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot activé sur le repo avec la même configuration que sur nos autres repos.