### PR TITLE
perf(bilans_financiers): use BCE/INPI (data.economie.gouv.fr) parquet files for faster ingestion

### DIFF
--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -11,6 +11,8 @@ from typing import Literal
 from unicodedata import normalize
 from urllib.parse import urlparse
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pandas as pd
 import requests
 
@@ -629,6 +631,21 @@ def fetch_hyperlink_from_page(url: str, search_text: str) -> str:
     logging.info(f"Likely found the hyperlink: {hyperlink}")
 
     return hyperlink
+
+
+def read_parquet_batches(filepath, batch_size=100000, columns=None):
+    """Read a Parquet file in batches, casting all columns to string.
+
+    Equivalent to pd.read_csv(..., chunksize=batch_size, dtype=str) for Parquet files.
+    Null values are preserved as None/NaN (same behavior as dtype=str with CSV).
+    """
+    pf = pq.ParquetFile(filepath)
+    for batch in pf.iter_batches(batch_size=batch_size, columns=columns):
+        string_arrays = [col.cast(pa.string()) for col in batch.columns]
+        string_batch = pa.RecordBatch.from_arrays(
+            string_arrays, names=batch.schema.names
+        )
+        yield string_batch.to_pandas()
 
 
 def is_url_valid(url: str) -> bool:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ requests==2.33.1
 pytest==9.0.2
 pydantic==2.12.5
 pyproj==3.7.2
+pyarrow==20.0.0
 redis==7.4.0

--- a/tests/test_parquet_integration.py
+++ b/tests/test_parquet_integration.py
@@ -1,0 +1,166 @@
+"""Integration test: download real Parquet from data.gouv.fr and validate.
+
+Usage:
+    python -m tests.test_parquet_integration [--file stock_ul|hist_ul|hist_etab] [--limit N]
+
+Downloads the actual INSEE Parquet file to /tmp, reads it with read_parquet_batches,
+and validates schema + data integrity. No Airflow required.
+"""
+
+import argparse
+import logging
+import time
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import requests
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def read_parquet_batches(filepath, batch_size=100000, columns=None):
+    """Standalone copy of helpers.utils.read_parquet_batches (no Airflow deps)."""
+    pf = pq.ParquetFile(filepath)
+    for batch in pf.iter_batches(batch_size=batch_size, columns=columns):
+        string_arrays = [col.cast(pa.string()) for col in batch.columns]
+        string_batch = pa.RecordBatch.from_arrays(
+            string_arrays, names=batch.schema.names
+        )
+        yield string_batch.to_pandas()
+
+
+PARQUET_SOURCES = {
+    "stock_ul": {
+        "url": "https://object.files.data.gouv.fr/data-pipeline-open/siren/stock/StockUniteLegale_utf8.parquet",
+        "expected_columns": [
+            "siren",
+            "dateCreationUniteLegale",
+            "denominationUniteLegale",
+            "categorieJuridiqueUniteLegale",
+            "etatAdministratifUniteLegale",
+            "statutDiffusionUniteLegale",
+        ],
+        "min_rows": 25_000_000,
+    },
+    "hist_ul": {
+        "url": "https://object.files.data.gouv.fr/data-pipeline-open/siren/stock/StockUniteLegaleHistorique_utf8.parquet",
+        "expected_columns": [
+            "siren",
+            "dateFin",
+            "dateDebut",
+            "etatAdministratifUniteLegale",
+            "changementEtatAdministratifUniteLegale",
+            "nicSiegeUniteLegale",
+        ],
+        "min_rows": 30_000_000,
+    },
+    "hist_etab": {
+        "url": "https://object.files.data.gouv.fr/data-pipeline-open/siren/stock/StockEtablissementHistorique_utf8.parquet",
+        "expected_columns": [
+            "siren",
+            "siret",
+            "dateFin",
+            "dateDebut",
+            "etatAdministratifEtablissement",
+            "changementEtatAdministratifEtablissement",
+        ],
+        "min_rows": 40_000_000,
+    },
+}
+
+
+def download_if_missing(url: str, dest: Path) -> Path:
+    if dest.exists():
+        logging.info(f"Using cached file: {dest} ({dest.stat().st_size / 1e6:.0f} MB)")
+        return dest
+
+    logging.info(f"Downloading {url}...")
+    t0 = time.time()
+    r = requests.get(url, stream=True)
+    r.raise_for_status()
+    with open(dest, "wb") as f:
+        for chunk in r.iter_content(chunk_size=8192):
+            f.write(chunk)
+    elapsed = time.time() - t0
+    size_mb = dest.stat().st_size / 1e6
+    logging.info(f"Downloaded {size_mb:.0f} MB in {elapsed:.0f}s")
+    return dest
+
+
+def validate(file_key: str, limit: int | None):
+    source = PARQUET_SOURCES[file_key]
+    dest = Path(f"/tmp/test_{file_key}.parquet")
+
+    # 1. Download
+    download_if_missing(source["url"], dest)
+
+    # 2. Check schema with PyArrow metadata (no data loaded)
+    pf = pq.ParquetFile(dest)
+    schema = pf.schema_arrow
+    col_names = schema.names
+    logging.info(f"\nSchema: {len(col_names)} columns, {pf.metadata.num_rows} rows")
+    logging.info(f"Columns: {col_names[:10]}{'...' if len(col_names) > 10 else ''}")
+
+    for expected_col in source["expected_columns"]:
+        assert expected_col in col_names, f"Missing expected column: {expected_col}"
+    logging.info("All expected columns present.")
+
+    assert pf.metadata.num_rows >= source["min_rows"], (
+        f"Expected >= {source['min_rows']} rows, got {pf.metadata.num_rows}"
+    )
+    logging.info(f"Row count OK: {pf.metadata.num_rows:,}")
+
+    # 3. Read with read_parquet_batches and validate
+    total_rows = 0
+    batch_count = 0
+    t0 = time.time()
+
+    for df in read_parquet_batches(str(dest), batch_size=100_000):
+        batch_count += 1
+        total_rows += len(df)
+
+        # Validate all values are strings or null
+        for col in df.columns:
+            assert pd.api.types.is_string_dtype(df[col]), (
+                f"Batch {batch_count}, col {col}: dtype={df[col].dtype}, expected string"
+            )
+
+        if batch_count == 1:
+            logging.info("\nFirst batch sample (5 rows):")
+            logging.info(df.head().to_string())
+
+        if limit and total_rows >= limit:
+            logging.info(f"\nStopped after {limit} rows (--limit)")
+            break
+
+    elapsed = time.time() - t0
+    logging.info(
+        f"\nRead {total_rows:,} rows in {batch_count} batches ({elapsed:.1f}s)"
+    )
+    logging.info(f"Speed: {total_rows / elapsed:,.0f} rows/s")
+    logging.info("PASS")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test Parquet stock SIRENE")
+    parser.add_argument(
+        "--file",
+        choices=list(PARQUET_SOURCES.keys()),
+        default="hist_ul",
+        help="Which file to test (default: hist_ul, smallest)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=500_000,
+        help="Max rows to read (default: 500000, 0=all)",
+    )
+    args = parser.parse_args()
+
+    validate(args.file, args.limit or None)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/test_read_parquet_batches.py
+++ b/tests/unit_tests/test_read_parquet_batches.py
@@ -1,0 +1,143 @@
+"""Tests for read_parquet_batches — validates Parquet reading matches CSV dtype=str behavior."""
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from data_pipelines_annuaire.helpers.utils import read_parquet_batches
+
+# Columns matching StockUniteLegale schema (subset)
+SAMPLE_COLUMNS = [
+    "siren",
+    "dateCreationUniteLegale",
+    "denominationUniteLegale",
+    "categorieJuridiqueUniteLegale",
+    "trancheEffectifsUniteLegale",
+    "etatAdministratifUniteLegale",
+]
+
+
+@pytest.fixture
+def sample_parquet(tmp_path):
+    """Create a sample Parquet file with mixed types and nulls."""
+    table = pa.table(
+        {
+            "siren": pa.array(["123456789", "987654321", "111222333", None]),
+            "dateCreationUniteLegale": pa.array(
+                ["2020-01-15", "2019-06-30", None, "2021-12-01"]
+            ),
+            "denominationUniteLegale": pa.array(
+                ["ACME SAS", None, "FOO SARL", "BAR & CIE"]
+            ),
+            "categorieJuridiqueUniteLegale": pa.array([5710, 5499, 1000, None]),
+            "trancheEffectifsUniteLegale": pa.array(
+                ["11", "00", None, "22"], type=pa.string()
+            ),
+            "etatAdministratifUniteLegale": pa.array(["A", "A", "C", "A"]),
+        }
+    )
+    path = tmp_path / "test_stock.parquet"
+    pq.write_table(table, path)
+    return path
+
+
+@pytest.fixture
+def equivalent_csv(tmp_path):
+    """Create the same data as CSV for comparison."""
+    df = pd.DataFrame(
+        {
+            "siren": ["123456789", "987654321", "111222333", None],
+            "dateCreationUniteLegale": ["2020-01-15", "2019-06-30", None, "2021-12-01"],
+            "denominationUniteLegale": ["ACME SAS", None, "FOO SARL", "BAR & CIE"],
+            "categorieJuridiqueUniteLegale": [5710, 5499, 1000, None],
+            "trancheEffectifsUniteLegale": ["11", "00", None, "22"],
+            "etatAdministratifUniteLegale": ["A", "A", "C", "A"],
+        }
+    )
+    path = tmp_path / "test_stock.csv"
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_all_values_are_strings(sample_parquet):
+    """All non-null values must be strings (matches dtype=str behavior)."""
+    for df in read_parquet_batches(str(sample_parquet)):
+        for col in df.columns:
+            non_null = df[col].dropna()
+            assert all(isinstance(v, str) for v in non_null), (
+                f"Column {col} has non-string values"
+            )
+
+
+def test_nulls_are_preserved(sample_parquet):
+    """Null values must remain NaN/None, not become 'None' or 'nan' strings."""
+    for df in read_parquet_batches(str(sample_parquet)):
+        # siren row 4 is null
+        assert pd.isna(df["siren"].iloc[3])
+        # dateCreation row 3 is null
+        assert pd.isna(df["dateCreationUniteLegale"].iloc[2])
+        # denomination row 2 is null
+        assert pd.isna(df["denominationUniteLegale"].iloc[1])
+        # categorieJuridique row 4 is null
+        assert pd.isna(df["categorieJuridiqueUniteLegale"].iloc[3])
+
+
+def test_integers_become_strings(sample_parquet):
+    """Integer columns in Parquet must be cast to strings."""
+    for df in read_parquet_batches(str(sample_parquet)):
+        assert df["categorieJuridiqueUniteLegale"].iloc[0] == "5710"
+        assert df["categorieJuridiqueUniteLegale"].iloc[1] == "5499"
+
+
+def test_column_selection(sample_parquet):
+    """columns parameter filters at read time."""
+    cols = ["siren", "etatAdministratifUniteLegale"]
+    for df in read_parquet_batches(str(sample_parquet), columns=cols):
+        assert list(df.columns) == cols
+
+
+def test_batch_size_produces_multiple_batches(tmp_path):
+    """With small batch_size, large files produce multiple batches."""
+    # 100 rows, batch_size=30 -> 4 batches (30+30+30+10)
+    table = pa.table(
+        {
+            "siren": pa.array([f"{i:09d}" for i in range(100)]),
+            "nom": pa.array([f"entreprise_{i}" for i in range(100)]),
+        }
+    )
+    path = tmp_path / "big.parquet"
+    pq.write_table(table, path)
+
+    batches = list(read_parquet_batches(str(path), batch_size=30))
+    assert len(batches) >= 3
+    total_rows = sum(len(b) for b in batches)
+    assert total_rows == 100
+
+
+def _normalize_numeric_string(val):
+    """Strip trailing '.0' from pandas float-string artifacts (e.g. '5710.0' -> '5710')."""
+    if val.endswith(".0"):
+        try:
+            return str(int(float(val)))
+        except ValueError:
+            return val
+    return val
+
+
+def test_matches_csv_dtype_str(sample_parquet, equivalent_csv):
+    """Parquet output matches pd.read_csv(dtype=str) for non-null values (modulo float artifacts)."""
+    parquet_dfs = list(read_parquet_batches(str(sample_parquet)))
+    csv_df = pd.read_csv(str(equivalent_csv), dtype=str)
+
+    parquet_df = pd.concat(parquet_dfs, ignore_index=True)
+
+    for col in parquet_df.columns:
+        for i in range(len(parquet_df)):
+            pval = parquet_df[col].iloc[i]
+            cval = csv_df[col].iloc[i]
+            if pd.isna(pval) and pd.isna(cval):
+                continue
+            assert pval == _normalize_numeric_string(cval), (
+                f"Mismatch at row {i}, col {col}: parquet={pval!r} vs csv={cval!r}"
+            )

--- a/workflows/data_pipelines/bilans_financiers/config.py
+++ b/workflows/data_pipelines/bilans_financiers/config.py
@@ -1,5 +1,4 @@
 from data_pipelines_annuaire.config import (
-    DATA_GOUV_BASE_URL,
     OBJECT_STORAGE_BASE_URL,
     DataSourceConfig,
 )
@@ -11,9 +10,9 @@ BILANS_FINANCIERS_CONFIG = DataSourceConfig(
     file_name="synthese_bilans",
     files_to_download={
         "bilans_financiers": {
-            "url": f"{DATA_GOUV_BASE_URL}9d213815-1649-4527-9eb4-427146ef2e5b",
+            "url": "https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/ratios_inpi_bce/exports/parquet?use_labels=true",
             "resource_id": "9d213815-1649-4527-9eb4-427146ef2e5b",
-            "destination": f"{DataSourceConfig.base_tmp_folder}/bilans_financiers/bilans-financiers-download.csv",
+            "destination": f"{DataSourceConfig.base_tmp_folder}/bilans_financiers/bilans-financiers-download.parquet",
         }
     },
     url_object_storage=f"{OBJECT_STORAGE_BASE_URL}bilans_financiers/latest/synthese_bilans.csv",

--- a/workflows/data_pipelines/bilans_financiers/processor.py
+++ b/workflows/data_pipelines/bilans_financiers/processor.py
@@ -7,7 +7,7 @@ from data_pipelines_annuaire.helpers import (
     Notification,
     clean_sirent_column,
 )
-from data_pipelines_annuaire.helpers.utils import get_fiscal_year
+from data_pipelines_annuaire.helpers.utils import get_fiscal_year, read_parquet_batches
 from data_pipelines_annuaire.workflows.data_pipelines.bilans_financiers.config import (
     BILANS_FINANCIERS_CONFIG,
 )
@@ -18,18 +18,18 @@ class BilansFinanciersProcessor(DataProcessor):
         super().__init__(BILANS_FINANCIERS_CONFIG)
 
     def preprocess_data(self) -> None:
-        df_bilan = pd.read_csv(
-            self.config.files_to_download["bilans_financiers"]["destination"],
-            dtype=str,
-            sep=";",
-            usecols=[
-                "siren",
-                "Chiffre_d_affaires",
-                "Resultat_net",
-                "date_cloture_exercice",
-                "type_bilan",
-            ],
-            encoding="utf-8-sig",
+        df_bilan = pd.concat(
+            read_parquet_batches(
+                self.config.files_to_download["bilans_financiers"]["destination"],
+                columns=[
+                    "siren",
+                    "chiffre_d_affaires",
+                    "resultat_net",
+                    "date_cloture_exercice",
+                    "type_bilan",
+                ],
+            ),
+            ignore_index=True,
         )
 
         # Comptes consolidés (consolidated accounts) are published before the 15th of June
@@ -38,8 +38,7 @@ class BilansFinanciersProcessor(DataProcessor):
         df_bilan = (
             df_bilan.rename(
                 columns={
-                    "Chiffre_d_affaires": "ca",
-                    "Resultat_net": "resultat_net",
+                    "chiffre_d_affaires": "ca",
                 }
             )
             .assign(
@@ -93,9 +92,6 @@ class BilansFinanciersProcessor(DataProcessor):
                 ]
             )
         )
-
-        df_bilan["ca"] = df_bilan["ca"].astype(float)
-        df_bilan["resultat_net"] = df_bilan["resultat_net"].astype(float)
 
         # Clean siren column and remove invalid rows
         df_bilan = clean_sirent_column(df_bilan, column_type="siren")


### PR DESCRIPTION
Switch bilans financiers source from data.gouv CSV to data.economie.gouv.fr Parquet export. 
Add read_parquet_batches utility for batch Parquet reading with dtype=str behavior matching CSV ingestion.