### PR TITLE
fix(etl): geo stats coord_source

### DIFF
--- a/workflows/data_pipelines/etl/data_fetch_clean/etablissements.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/etablissements.py
@@ -214,7 +214,7 @@ def preprocess_etablissement_data(file_type: Literal["stock", "flux"]):
         df_chunk["coord_source"] = df_chunk.apply(
             lambda row: (
                 file_type
-                if row["latitude"] is not None and row["longitude"] is not None
+                if pd.notna(row["latitude"]) and pd.notna(row["longitude"])
                 else f"{file_type}_vide"
             ),
             axis=1,


### PR DESCRIPTION
`sans coordonnées` should not be at 0.
<img width="335" height="176" alt="image" src="https://github.com/user-attachments/assets/b9d47f3d-3a46-4ae6-abe6-5e2aa1e2560d" />

Ran correctly on dev-01 ✅ 
```
[2026-04-20 09:28:02] INFO - 📍 Statistiques de géocodage (hors entreprises étrangères et non-diffusibles) :<ul><li> Total de géocodés: 99.77%</li><li>geo_stats: 99.11%</li><li>flux: 0.22%</li><li>stock: 0.45%</li><li>sans coordonnées: 0.23%</li>
```