### PR TITLE
feat: add bodacc data to the db

### DIFF
--- a/helpers/data_processor.py
+++ b/helpers/data_processor.py
@@ -17,6 +17,7 @@ from data_pipelines_annuaire.helpers.notification import Notification, monitorin
 from data_pipelines_annuaire.helpers.object_storage import File, ObjectStorageClient
 from data_pipelines_annuaire.helpers.utils import (
     download_file,
+    fetch_data_processed_from_huwise,
     fetch_hyperlink_from_page,
     get_date_last_modified,
     save_to_metadata,
@@ -45,6 +46,7 @@ class DataProcessor(ABC):
             - destination (str): The local path to save the file.
             - dataset_id (optional, str): Indicates the resource has to be fetched from the dataset.
             - pattern (optional, str): The pattern to search for in the URL page to find the actual file link.
+            - huwise (optional, bool): If True indicates the updated date metadata can be fetched from their API.
         """
         ti = get_current_context()["ti"]
 
@@ -211,6 +213,10 @@ class DataProcessor(ABC):
                 elif "dataset_id" in params:
                     resource_id, _ = fetch_last_resource_from_dataset(params["url"])
                     date_list.append(fetch_last_modified_date(resource_id))
+                elif params.get("huwise", False):
+                    date_list.append(
+                        fetch_data_processed_from_huwise(params["huwise_url"])
+                    )
                 elif "url" in params:
                     url_date = get_date_last_modified(url=params["url"])
                     if url_date:

--- a/helpers/data_processor.py
+++ b/helpers/data_processor.py
@@ -214,9 +214,7 @@ class DataProcessor(ABC):
                     resource_id, _ = fetch_last_resource_from_dataset(params["url"])
                     date_list.append(fetch_last_modified_date(resource_id))
                 elif params.get("huwise", False):
-                    date_list.append(
-                        fetch_data_processed_from_huwise(params["huwise_url"])
-                    )
+                    date_list.append(fetch_data_processed_from_huwise(params["url"]))
                 elif "url" in params:
                     url_date = get_date_last_modified(url=params["url"])
                     if url_date:

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -651,3 +651,32 @@ def is_url_valid(url: str) -> bool:
 
 def html_to_text(html_string):
     return re.sub(r"<[^>]+>", " ", html_string).strip()
+
+
+def fetch_data_processed_from_huwise(huwise_url: str) -> str:
+    """
+    Fetch the 'data_processed' field from an Huwise dataset API.
+
+    Derives the dataset metadata URL from an export URL by removing
+    '/exports/...' and query parameters.
+
+    Args:
+        huwise_url: An Huwise export URL
+            (e.g., https://example.com/api/.../datasets/my-dataset/exports/csv?...)
+
+    Returns:
+        The 'data_processed' ISO datetime string, or None if not found.
+    """
+    parsed = urlparse(huwise_url)
+    path = parsed.path
+
+    exports_index = path.find("/exports")
+    if exports_index != -1:
+        path = path[:exports_index] + "/"
+
+    metadata_url = f"{parsed.scheme}://{parsed.netloc}{path}"
+
+    response = requests.get(metadata_url, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    return data["metas"]["default"]["data_processed"]

--- a/workflows/data_pipelines/bodacc/README.md
+++ b/workflows/data_pipelines/bodacc/README.md
@@ -1,0 +1,13 @@
+# Documentation
+
+:warning: L'exploitation de ces données est encore en phase de test et de développement.
+
+## bodacc
+
+| Information | Valeur |
+| -------- | -------- |
+| Fichier source | `dag.py` |
+| Description | Ce traitement permet de récupérer les radiations et procédures collectives publiées au BODACC. |
+| Fréquence | Quotidienne |
+| Données sources | [Annonces Commerciales](https://www.bodacc.fr/explore/dataset/annonces-commerciales/) |
+| Données de sorties | Object Storage |

--- a/workflows/data_pipelines/bodacc/config.py
+++ b/workflows/data_pipelines/bodacc/config.py
@@ -1,0 +1,46 @@
+from data_pipelines_annuaire.config import (
+    OBJECT_STORAGE_BASE_URL,
+    DataSourceConfig,
+)
+
+BODACC_CONFIG = DataSourceConfig(
+    name="bodacc",
+    tmp_folder=f"{DataSourceConfig.base_tmp_folder}/bodacc",
+    object_storage_path="bodacc",
+    file_name="bodacc",
+    files_to_download={
+        "procedures_collectives": {
+            "huwise": True,
+            "url": "https://bodacc-datadila.opendatasoft.com/api/explore/v2.1/catalog/datasets/annonces-commerciales/exports/csv?lang=fr&refine=familleavis_lib%3A%22Proc%C3%A9dures%20collectives%22&timezone=Europe%2FParis&use_labels=true&delimiter=%3B",
+            "destination": f"{DataSourceConfig.base_tmp_folder}/bodacc/procedures-collectives-raw.csv",
+        },
+        "radiations": {
+            "huwise": True,
+            "url": "https://bodacc-datadila.opendatasoft.com/api/explore/v2.1/catalog/datasets/annonces-commerciales/exports/csv?lang=fr&refine=familleavis%3A%22radiation%22&timezone=Europe%2FBerlin&use_labels=true&delimiter=%3B",
+            "destination": f"{DataSourceConfig.base_tmp_folder}/bodacc/radiations-raw.csv",
+        },
+    },
+    url_object_storage=f"{OBJECT_STORAGE_BASE_URL}bodacc/latest/bodacc.csv",
+    url_object_storage_metadata=f"{OBJECT_STORAGE_BASE_URL}bodacc/latest/metadata.json",
+    table_ddl="""
+        BEGIN;
+        CREATE TABLE IF NOT EXISTS bodacc
+        (
+            siren TEXT PRIMARY KEY,
+            id_radiation TEXT,
+            est_radie_rcs INTEGER,
+            date_radiation TEXT,
+            date_radiation_str TEXT,
+            date_publication_radiation TEXT,
+            date_publication_radiation_str TEXT,
+            id_procedure TEXT,
+            nature_jugement TEXT,
+            date_jugement TEXT,
+            date_jugement_str TEXT,
+            date_publication_procedure TEXT,
+            date_publication_procedure_str TEXT,
+            procedure_collective_cloturee_nature TEXT
+        );
+        COMMIT;
+    """,
+)

--- a/workflows/data_pipelines/bodacc/dag.py
+++ b/workflows/data_pipelines/bodacc/dag.py
@@ -1,0 +1,69 @@
+from datetime import timedelta
+
+import pendulum
+from airflow.sdk import dag, task
+
+from data_pipelines_annuaire.config import EMAIL_LIST
+from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.workflows.data_pipelines.bodacc.processor import (
+    BodaccProcessor,
+)
+
+default_args = {
+    "depends_on_past": False,
+    "email_on_failure": True,
+    "email_on_retry": False,
+    "email": EMAIL_LIST,
+    "retries": 1,
+}
+
+
+@dag(
+    tags=["bodacc"],
+    default_args=default_args,
+    schedule="0 16 * * *",
+    start_date=pendulum.today("UTC").add(days=-8),
+    dagrun_timeout=timedelta(minutes=60),
+    params={},
+    catchup=False,
+    on_failure_callback=Notification(),
+    on_success_callback=Notification(),
+)
+def data_processing_bodacc():
+    bodacc_processor = BodaccProcessor()
+
+    @task.bash
+    def clean_previous_outputs():
+        return f"rm -rf {bodacc_processor.config.tmp_folder} && mkdir -p {bodacc_processor.config.tmp_folder}"
+
+    @task
+    def download_data():
+        return bodacc_processor.download_data()
+
+    @task
+    def preprocess_data():
+        return bodacc_processor.preprocess_data()
+
+    @task
+    def save_date_last_modified():
+        return bodacc_processor.save_date_last_modified()
+
+    @task
+    def send_file_to_object_storage():
+        return bodacc_processor.send_file_to_object_storage()
+
+    @task
+    def compare_files_object_storage():
+        return bodacc_processor.compare_files_object_storage()
+
+    return (
+        clean_previous_outputs()
+        >> download_data()
+        >> preprocess_data()
+        >> save_date_last_modified()
+        >> send_file_to_object_storage()
+        >> compare_files_object_storage()
+    )
+
+
+data_processing_bodacc()

--- a/workflows/data_pipelines/bodacc/processor.py
+++ b/workflows/data_pipelines/bodacc/processor.py
@@ -1,0 +1,333 @@
+import logging
+
+import pandas as pd
+
+from data_pipelines_annuaire.helpers import (
+    DataProcessor,
+    Notification,
+)
+from data_pipelines_annuaire.helpers.data_quality import clean_sirent_column
+from data_pipelines_annuaire.workflows.data_pipelines.bodacc.config import (
+    BODACC_CONFIG,
+)
+from data_pipelines_annuaire.workflows.data_pipelines.bodacc.utils import (
+    extract_siren_from_registre,
+    filter_cancelled_announcements,
+    is_cloture,
+    parse_jugement_json,
+    parse_radiation_json,
+)
+
+
+def process_radiation_chunk(chunk: pd.DataFrame) -> pd.DataFrame:
+    """Traiter un chunk de données radiations."""
+    chunk = extract_siren_from_registre(chunk)
+
+    # Nettoyer et valider les SIREN
+    chunk = clean_sirent_column(
+        chunk,
+        column_type="siren",
+        column_name="siren",
+        add_leading_zeros=True,
+        max_removal_percentage=0.1,
+    )
+
+    if chunk.empty:
+        return chunk
+
+    # Parser le JSON radiationaurcs pour extraire la date
+    chunk["date_radiation"] = chunk["radiationaurcs"].apply(parse_radiation_json)
+
+    # Marquer comme radié (présent dans le fichier = radié)
+    chunk["est_radie_rcs"] = True
+
+    # Garder uniquement les colonnes nécessaires
+    chunk["date_publication_radiation"] = chunk["dateparution"]
+    chunk["id_radiation"] = chunk["id"]
+    return chunk[
+        [
+            "siren",
+            "id_radiation",
+            "est_radie_rcs",
+            "date_radiation",
+            "date_publication_radiation",
+        ]
+    ]
+
+
+def process_procedure_chunk(chunk: pd.DataFrame) -> pd.DataFrame:
+    """Traiter un chunk de données procédures collectives."""
+    chunk = extract_siren_from_registre(chunk)
+
+    # Nettoyer et valider les SIREN
+    chunk = clean_sirent_column(
+        chunk,
+        column_type="siren",
+        column_name="siren",
+        add_leading_zeros=True,
+        max_removal_percentage=0.1,
+    )
+
+    if chunk.empty:
+        return chunk
+
+    # Parser le JSON jugement (famille, nature, date)
+    chunk["jugement_parsed"] = chunk["jugement"].apply(parse_jugement_json)
+    chunk["famille_jugement"] = chunk["jugement_parsed"].apply(
+        lambda x: x.get("famille", "") if x else ""
+    )
+
+    # Exclure les familles non pertinentes
+    familles_exclues = ["Avis de dépôt", "Extrait de jugement"]
+    chunk = chunk[~chunk["famille_jugement"].isin(familles_exclues)]
+
+    if chunk.empty:
+        return chunk
+
+    chunk["nature_jugement"] = chunk["jugement_parsed"].apply(
+        lambda x: x.get("nature", "") if x else ""
+    )
+    chunk["date_jugement"] = chunk["jugement_parsed"].apply(
+        lambda x: x.get("date", "") if x else ""
+    )
+
+    # Garder uniquement les colonnes nécessaires
+    chunk["date_publication_procedure"] = chunk["dateparution"]
+    chunk["id_procedure"] = chunk["id"]
+    return chunk[
+        [
+            "siren",
+            "id_procedure",
+            "famille_jugement",
+            "nature_jugement",
+            "date_jugement",
+            "date_publication_procedure",
+        ]
+    ]
+
+
+class BodaccProcessor(DataProcessor):
+    CHUNK_SIZE = 100_000
+
+    COLUMNS_RADIATIONS = [
+        "id",
+        "registre",
+        "dateparution",
+        "typeavis",
+        "radiationaurcs",
+        "parutionavisprecedent",
+    ]
+    COLUMNS_PROCEDURES = [
+        "id",
+        "registre",
+        "dateparution",
+        "typeavis",
+        "jugement",
+        "parutionavisprecedent",
+    ]
+
+    def __init__(self):
+        super().__init__(BODACC_CONFIG)
+
+    def preprocess_data(self):
+        logging.info("Processing BODACC data...")
+
+        df_radiations = self._process_radiations()
+        logging.info(f"Radiations: {len(df_radiations)} unique SIRENs")
+
+        df_procedures = self._process_procedures_collectives()
+        logging.info(f"Procédures collectives: {len(df_procedures)} unique SIRENs")
+
+        df = pd.merge(
+            df_radiations,
+            df_procedures,
+            on="siren",
+            how="outer",
+        )
+        logging.info(f"After merge: {len(df)} unique SIRENs")
+        df.to_csv(f"{self.config.tmp_folder}/{self.config.file_name}.csv", index=False)
+
+        DataProcessor.push_message(
+            Notification.notification_xcom_key,
+            description=f"{len(df)} Siren traités au BODACC\n* radiations : {len(df_radiations)}\n* procédures collectives : {len(df_procedures)}",
+        )
+
+    def _process_radiations(self) -> pd.DataFrame:
+        logging.info("Processing radiations...")
+        chunks_processed = []
+        total_rows = 0
+
+        # Charger le fichier complet pour gérer les annulations
+        df_full = pd.read_csv(
+            self.config.files_to_download["radiations"]["destination"],
+            dtype=str,
+            sep=";",
+            usecols=self.COLUMNS_RADIATIONS,
+        )
+        total_rows = len(df_full)
+        logging.info(f"Loaded {total_rows} radiation rows")
+
+        # Filtrer les annulations
+        df_full = filter_cancelled_announcements(df_full)
+        logging.info(f"After filtering cancellations: {len(df_full)} rows")
+
+        # Traiter par chunks pour la mémoire
+        for i in range(0, len(df_full), self.CHUNK_SIZE):
+            chunk = df_full.iloc[i : i + self.CHUNK_SIZE]
+            processed = process_radiation_chunk(chunk)
+            if not processed.empty:
+                chunks_processed.append(processed)
+
+        if not chunks_processed:
+            logging.warning("No radiations found")
+            return pd.DataFrame(
+                columns=[
+                    "siren",
+                    "id_radiation",
+                    "est_radie_rcs",
+                    "date_radiation",
+                    "date_radiation_str",
+                    "date_publication_radiation",
+                    "date_publication_radiation_str",
+                ]
+            )
+
+        # Concaténer tous les chunks
+        df = pd.concat(chunks_processed, ignore_index=True)
+
+        # Renommer les colonnes string et créer les colonnes datetime
+        df["date_radiation_str"] = df["date_radiation"]
+        df["date_radiation"] = pd.to_datetime(
+            df["date_radiation_str"], errors="coerce", format="%Y-%m-%d"
+        )
+        df["date_publication_radiation_str"] = df["date_publication_radiation"]
+        df["date_publication_radiation"] = pd.to_datetime(
+            df["date_publication_radiation_str"], errors="coerce", format="%Y-%m-%d"
+        )
+
+        # Dédupliquer par Siren en gardant la radiation la plus récente
+        df = df.sort_values(
+            ["date_radiation", "date_publication_radiation"], ascending=[False, False]
+        )
+        duplicated_mask = df.duplicated(subset=["siren"], keep="first")
+        n_duplicates = duplicated_mask.sum()
+        if n_duplicates > 0:
+            sample_sirens = df.loc[duplicated_mask, "siren"].head(5).tolist()
+            logging.info(
+                f"Radiations: {n_duplicates} duplicate Siren, sample:\n{sample_sirens}"
+            )
+        df = df.drop_duplicates(subset=["siren"], keep="first")
+
+        return df[
+            [
+                "siren",
+                "id_radiation",
+                "est_radie_rcs",
+                "date_radiation",
+                "date_radiation_str",
+                "date_publication_radiation",
+                "date_publication_radiation_str",
+            ]
+        ]
+
+    def _process_procedures_collectives(self) -> pd.DataFrame:
+        logging.info("Processing procédures collectives...")
+        chunks_processed = []
+        total_rows = 0
+
+        # Charger le fichier complet pour gérer les annulations
+        df_full = pd.read_csv(
+            self.config.files_to_download["procedures_collectives"]["destination"],
+            dtype=str,
+            sep=";",
+            usecols=self.COLUMNS_PROCEDURES,
+        )
+        total_rows = len(df_full)
+        logging.info(f"Loaded {total_rows} procedure rows")
+
+        # Filtrer les annulations et rétractations
+        df_full = filter_cancelled_announcements(df_full)
+        logging.info(f"After filtering cancellations: {len(df_full)} rows")
+
+        # Traiter par chunks pour la mémoire
+        for i in range(0, len(df_full), self.CHUNK_SIZE):
+            chunk = df_full.iloc[i : i + self.CHUNK_SIZE]
+            processed = process_procedure_chunk(chunk)
+            if not processed.empty:
+                chunks_processed.append(processed)
+
+        if not chunks_processed:
+            logging.warning("No procedures collectives found")
+            return pd.DataFrame(
+                columns=[
+                    "siren",
+                    "id_procedure",
+                    "nature_jugement",
+                    "date_jugement",
+                    "date_jugement_str",
+                    "date_publication_procedure",
+                    "date_publication_procedure_str",
+                    "procedure_collective_cloturee_nature",
+                ]
+            )
+
+        # Concaténer tous les chunks
+        df = pd.concat(chunks_processed, ignore_index=True)
+
+        # Renommer les colonnes string et créer les colonnes datetime
+        df["date_jugement_str"] = df["date_jugement"]
+        df["date_jugement"] = pd.to_datetime(
+            df["date_jugement_str"], errors="coerce", format="%Y-%m-%d"
+        )
+        df["date_publication_procedure_str"] = df["date_publication_procedure"]
+        df["date_publication_procedure"] = pd.to_datetime(
+            df["date_publication_procedure_str"], errors="coerce", format="%Y-%m-%d"
+        )
+
+        # Dédupliquer par SIREN en gardant la procédure la plus récente
+        df = df.sort_values(
+            ["date_jugement", "date_publication_procedure"], ascending=[False, False]
+        )
+        duplicated_mask = df.duplicated(subset=["siren"], keep="first")
+        n_duplicates = duplicated_mask.sum()
+        if n_duplicates > 0:
+            sample_sirens = df.loc[duplicated_mask, "siren"].head(5).tolist()
+            logging.info(
+                f"Procedures: {n_duplicates} duplicate Siren, sample:\n{sample_sirens}"
+            )
+        df = df.drop_duplicates(subset=["siren"], keep="first")
+
+        # Déterminer si la procédure la plus récente est une clôture
+        df["is_cloture"] = df["famille_jugement"].apply(is_cloture)
+
+        # Créer les colonnes finales
+        df["procedure_collective_cloturee_nature"] = df.apply(
+            lambda row: row["nature_jugement"] if row["is_cloture"] else "",
+            axis=1,
+        )
+        df["nature_jugement_final"] = df.apply(
+            lambda row: "" if row["is_cloture"] else row["nature_jugement"],
+            axis=1,
+        )
+
+        # Renommer pour l'export
+        df["nature_jugement"] = df["nature_jugement_final"]
+
+        logging.info(
+            f"Procedures: {len(df)} unique SIRENs, "
+            f"{df['is_cloture'].sum()} clôturées, "
+            f"{(~df['is_cloture']).sum()} en cours"
+        )
+
+        return df[
+            [
+                "siren",
+                "id_procedure",
+                "nature_jugement",
+                "date_jugement",
+                "date_jugement_str",
+                "date_publication_procedure",
+                "date_publication_procedure_str",
+                "procedure_collective_cloturee_nature",
+            ]
+        ]

--- a/workflows/data_pipelines/bodacc/utils.py
+++ b/workflows/data_pipelines/bodacc/utils.py
@@ -61,7 +61,7 @@ def parse_date_bodacc(date_str: str) -> str:
 
 
 def parse_radiation_json(radiation_str: str) -> str:
-    """Extrait la date de cessation depuis le champs radiationaurcs."""
+    """Extrait la date de cessation depuis le champ radiationaurcs."""
     if pd.isna(radiation_str) or not radiation_str:
         return ""
     data = json.loads(radiation_str)

--- a/workflows/data_pipelines/bodacc/utils.py
+++ b/workflows/data_pipelines/bodacc/utils.py
@@ -1,0 +1,239 @@
+import json
+import re
+
+import pandas as pd
+
+
+def parse_date_bodacc(date_str: str) -> str:
+    """
+    Parse une date BODACC et retourne au format YYYY-MM-DD.
+    Gère les formats :
+        - big-endian : YYYY-MM-DD
+        - little-endian : JJ/MM/AAAA
+        - texte : 27 novembre 2008 ou 1er janvier 2020
+    """
+
+    MOIS_FR = {
+        "janvier": "01",
+        "février": "02",
+        "fevrier": "02",
+        "mars": "03",
+        "avril": "04",
+        "mai": "05",
+        "juin": "06",
+        "juillet": "07",
+        "août": "08",
+        "aout": "08",
+        "septembre": "09",
+        "octobre": "10",
+        "novembre": "11",
+        "décembre": "12",
+        "decembre": "12",
+    }
+
+    if pd.isna(date_str) or not date_str:
+        return ""
+
+    date_str = str(date_str).strip()
+
+    # Format ISO : YYYY-MM-DD
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
+        return date_str
+
+    # Format numérique : JJ/MM/AAAA
+    match = re.match(r"^(\d{2})/(\d{2})/(\d{4})$", date_str)
+    if match:
+        jour, mois, annee = match.groups()
+        return f"{annee}-{mois}-{jour}"
+
+    # Remplacer les espaces insécables par des espaces normaux
+    date_str = date_str.replace("\xa0", " ")
+
+    # Format français : "27 novembre 2008" ou "1er janvier 2020"
+    match = re.match(r"(\d{1,2})(?:er)?\s+(\w+)\s+(\d{4})", date_str)
+    if match:
+        jour, mois, annee = match.groups()
+        mois_num = MOIS_FR.get(mois.lower())
+        if mois_num:
+            return f"{annee}-{mois_num}-{jour.zfill(2)}"
+
+    return ""
+
+
+def parse_radiation_json(radiation_str: str) -> str:
+    """Extrait la date de cessation depuis le champs radiationaurcs."""
+    if pd.isna(radiation_str) or not radiation_str:
+        return ""
+    data = json.loads(radiation_str)
+    # Format acutel PP
+    if "dateCessationActivitePP" in data:
+        return parse_date_bodacc(data["dateCessationActivitePP"])
+    # Format obsolète PP
+    if "radiationPP" in data and isinstance(data["radiationPP"], dict):
+        return parse_date_bodacc(data["radiationPP"].get("dateCessationActivitePP", ""))
+    # Les PM n'ont pas de date de disponible
+    return ""
+
+
+def parse_jugement_json(jugement_str: str) -> dict:
+    """Parse le champs Json jugement et en extraire famille, nature et date."""
+    if pd.isna(jugement_str) or not jugement_str:
+        return {"famille": "", "nature": "", "date": ""}
+    try:
+        data = json.loads(jugement_str)
+        return {
+            "famille": data.get("famille", ""),
+            "nature": data.get("nature", ""),
+            "date": parse_date_bodacc(data.get("date", "")),
+        }
+    except json.JSONDecodeError:
+        return {"famille": "", "nature": "", "date": ""}
+
+
+def is_procedure_en_cours(nature: str) -> bool:
+    """Vérifie si la nature de jugement correspond à une procédure en cours."""
+    NATURES_CLOTURE = [
+        "clôture",
+        "cloture",
+        "clotûre",
+        "plan arrêté",
+        "plan arrete",
+        "arrêtant le plan",
+        "arretant le plan",
+    ]
+    if pd.isna(nature) or not nature:
+        return False
+    nature_lower = nature.lower()
+    return not any(kw in nature_lower for kw in NATURES_CLOTURE)
+
+
+def is_cloture(famille: str) -> bool:
+    """Vérifie si la famille correspond à une clôture de procédure."""
+    # Familles de jugement indiquant une clôture
+    FAMILLES_CLOTURE = [
+        "jugement de clôture",
+        "jugement de clÃ´ture",  # Encodage UTF-8 mal interprété
+    ]
+    if pd.isna(famille) or not famille:
+        return False
+    famille_lower = famille.lower()
+    return any(kw in famille_lower for kw in FAMILLES_CLOTURE)
+
+
+def is_retractation(famille: str) -> bool:
+    """Vérifie si la famille correspond à une rétractation (équivalent annulation)."""
+    # Familles équivalentes à une annulation
+    FAMILLES_ANNULATION = [
+        "rétractation sur tierce opposition",
+        # "retractation sur tierce opposition",
+    ]
+    if pd.isna(famille) or not famille:
+        return False
+    famille_lower = famille.lower()
+    return any(kw in famille_lower for kw in FAMILLES_ANNULATION)
+
+
+def build_bodacc_id(
+    code_publication: str, numero_parution: str | int, numero_annonce: str | int
+) -> str | None:
+    if code_publication and numero_parution and numero_annonce:
+        lettre = code_publication.split()[-1] if code_publication else ""
+        return f"{lettre}{numero_parution}{numero_annonce}"
+    return None
+
+
+def parse_json_safe(json_str: str) -> dict | None:
+    if pd.isna(json_str) or not json_str:
+        return None
+    try:
+        return json.loads(json_str)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def extract_cancelled_id_from_avis_precedent(avis_precedent_str: str) -> str | None:
+    """Extrait l'ID de l'annonce annulée depuis le champs Json parutionavisprecedent."""
+    avis = parse_json_safe(avis_precedent_str)
+    if not avis:
+        return None
+    return build_bodacc_id(
+        code_publication=avis.get("nomPublication", ""),
+        numero_parution=avis.get("numeroParution", ""),
+        numero_annonce=avis.get("numeroAnnonce", ""),
+    )
+
+
+def get_cancelled_ids(df: pd.DataFrame) -> set:
+    """Extrait les IDs des annonces annulées (annulations + rétractations)."""
+    cancelled_ids = set()
+
+    # Annulations explicites
+    annulations = df[df["typeavis"] == "annulation"]
+    if not annulations.empty:
+        ids_from_annulations = annulations["parutionavisprecedent"].apply(
+            extract_cancelled_id_from_avis_precedent
+        )
+        cancelled_ids.update(ids_from_annulations.dropna())
+
+    # Rétractations sur tierce opposition
+    # S'applique aux procédures collectives et non aux radiations
+    if "jugement" in df.columns:
+        familles = df["jugement"].apply(
+            lambda x: (
+                parse_json_safe(x).get("famille", "") if parse_json_safe(x) else ""
+            )
+        )
+        retractations = df[familles.apply(is_retractation)]
+        if not retractations.empty:
+            ids_from_retractations = retractations["parutionavisprecedent"].apply(
+                extract_cancelled_id_from_avis_precedent
+            )
+            cancelled_ids.update(ids_from_retractations.dropna())
+
+    return cancelled_ids
+
+
+def filter_cancelled_announcements(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Exclut :
+        - les annonces annulées
+        - les avis d'annulations
+        - les rétractations
+    """
+    cancelled_ids = get_cancelled_ids(df)
+
+    # Exclut les annonces annulées
+    df = df[~df["id"].isin(cancelled_ids)]
+
+    # Exclut les avis d'annulations
+    df = df[df["typeavis"] != "annulation"]
+
+    # Exclut aussi les rétractations elles-mêmes (seulement si colonne jugement existe)
+    if "jugement" in df.columns:
+        df = df.copy()
+        df["_famille"] = df["jugement"].apply(
+            lambda x: (
+                parse_json_safe(x).get("famille", "") if parse_json_safe(x) else ""
+            )
+        )
+        df = df[~df["_famille"].apply(is_retractation)]
+        df = df.drop(columns=["_famille"])
+
+    return df
+
+
+def extract_siren_from_registre(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Extrait le Siren depuis la colonne registre.
+    Exemple :
+        - formats d'input existants :
+            - "123 456 789,123456789"
+            - "123456789,123 456 789"
+        - output: "123456789"
+    """
+    df = df.copy()
+    df["siren"] = df["registre"].str.split(",").str[0].str.strip()
+    # Retire les Siren manquants avant clean_sirent_column afin de ne logger
+    # que les Siren avec un mauvais format
+    df = df[df["siren"].notna() & (df["siren"] != "")]
+    return df

--- a/workflows/data_pipelines/etl/dag.py
+++ b/workflows/data_pipelines/etl/dag.py
@@ -32,6 +32,9 @@ from data_pipelines_annuaire.workflows.data_pipelines.bilan_ges.config import (
 from data_pipelines_annuaire.workflows.data_pipelines.bilans_financiers.config import (
     BILANS_FINANCIERS_CONFIG,
 )
+from data_pipelines_annuaire.workflows.data_pipelines.bodacc.config import (
+    BODACC_CONFIG,
+)
 from data_pipelines_annuaire.workflows.data_pipelines.colter.config import (
     COLTER_CONFIG,
     ELUS_CONFIG,
@@ -206,6 +209,7 @@ def database_constructor():
             ALIM_CONFIANCE_CONFIG,
             BILAN_GES_CONFIG,
             AIDES_CONFIG,
+            BODACC_CONFIG,
         ]
         tasks = []
         for config in config_list:


### PR DESCRIPTION
Cette PR ajoute les fonctionnalités suivantes : 
* Télécharge le JDD du BODACC avec un préfiltrage sur les familles d'avis pour aller plus vite en deux parties (`radiation` et `Procédures Collectives`)
* Applique une logique en Beta par chunk pour extraire les dates de radiations et les procédures collectives
* Créé une table `bodacc` dans la base de données sqlite

À noter qu'il est nécessaire de parser l'API Huwise afin de récupérer la date de mise à jour des données donc un nouveau helper a été créé à cette fin.

Ce qu'elle ne fait pas : 
* Ne modifie en rien à l'index de l'API Recherche

À tourné dev-01 ✅ 