### PR TITLE
fix(es9): request timeout argument

### DIFF
--- a/workflows/data_pipelines/elasticsearch/task_functions/snapshot.py
+++ b/workflows/data_pipelines/elasticsearch/task_functions/snapshot.py
@@ -196,7 +196,7 @@ def delete_old_snapshots():
         hosts=[ELASTIC_URL],
         basic_auth=(ELASTIC_USER, ELASTIC_PASSWORD),
         retry_on_timeout=True,
-        timeout=60,
+        request_timeout=60,
     )
 
     elastic_connection = connections.get_connection()


### PR DESCRIPTION
Index snapshot dag failed in staging.
```TypeError: Elasticsearch.__init__() got an unexpected keyword argument 'timeout'```