### PR TITLE
build: upgrade airflow to 3.2.1

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -55,11 +55,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-airflow-3.1.6-pip-${{ hashFiles('data_pipelines_annuaire/requirements.txt') }}
+          key: ${{ runner.os }}-airflow-3.2.1-pip-${{ hashFiles('data_pipelines_annuaire/requirements.txt') }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install apache-airflow==3.1.6
+          python -m pip install apache-airflow==3.2.1
           python -m pip install -r data_pipelines_annuaire/requirements.txt
       - name: unit tests
         run: |

--- a/airflow.Dockerfile
+++ b/airflow.Dockerfile
@@ -1,0 +1,27 @@
+# This Dockerfile is used in production by l'Annuaire des Entreprises
+# Any modification should be thoroughly tested
+
+ARG AIRFLOW_VERSION=3.2.1
+ARG AIRFLOW_PYTHON_VERSION=3.12
+
+FROM apache/airflow:slim-${AIRFLOW_VERSION}-python${AIRFLOW_PYTHON_VERSION}
+
+ARG AIRFLOW_VERSION
+ARG AIRFLOW_PYTHON_VERSION
+
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git lftp zip wget p7zip-full gcc g++
+
+USER airflow
+
+RUN pip install --no-cache-dir \
+    "apache-airflow[postgres,statsd]==${AIRFLOW_VERSION}" \
+    "apache-airflow-providers-fab" \
+    "sentry-sdk" \
+    -c https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${AIRFLOW_PYTHON_VERSION}.txt
+
+COPY ./requirements.txt /opt/airflow/requirements.txt
+RUN pip install --no-cache-dir -r /opt/airflow/requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,11 @@
+# This docker compose configuration is not for production use
+# It's sole purpose is for local Airflow test and development
+
 services:
   airflow:
     build:
       context: .
-      dockerfile_inline: |
-        FROM apache/airflow:slim-3.1.6-python3.12
-        COPY requirements.txt /opt/airflow/requirements.txt
-        RUN pip install --no-cache-dir apache-airflow[postgres]==3.1.6
-        RUN pip install --no-cache-dir -r /opt/airflow/requirements.txt
+      dockerfile: airflow.Dockerfile
     restart: unless-stopped
     depends_on:
       postgres:

--- a/workflows/data_pipelines/achats_responsables/dag.py
+++ b/workflows/data_pipelines/achats_responsables/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -22,7 +21,7 @@ default_args = {
     tags=["achats_responsables", "label"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/agence_bio/dag.py
+++ b/workflows/data_pipelines/agence_bio/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -22,7 +21,7 @@ default_args = {
     tags=["agence bio", "certifications"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/aides_ademe/dag.py
+++ b/workflows/data_pipelines/aides_ademe/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -22,7 +21,7 @@ default_args = {
     tags=["aides ademe", "label"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/aides_minimis/dag.py
+++ b/workflows/data_pipelines/aides_minimis/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -22,7 +21,7 @@ default_args = {
     tags=["aides minimis", "label"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/alim_confiance/dag.py
+++ b/workflows/data_pipelines/alim_confiance/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -22,7 +21,7 @@ default_args = {
     tags=["alim_confiance", "label"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/bilan_ges/dag.py
+++ b/workflows/data_pipelines/bilan_ges/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -27,7 +26,7 @@ default_args = {
     tags=["bilan_ges"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/bilans_financiers/dag.py
+++ b/workflows/data_pipelines/bilans_financiers/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -22,7 +21,7 @@ default_args = {
     tags=["bilans financiers", "signaux faibles"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60 * 2),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/bodacc/dag.py
+++ b/workflows/data_pipelines/bodacc/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -22,7 +21,7 @@ default_args = {
     tags=["bodacc"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/colter/dag.py
+++ b/workflows/data_pipelines/colter/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import Asset, dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -29,7 +28,7 @@ dataset_colter = Asset(COLTER_CONFIG.name)
     tags=["collectivités", "communes", "régions", "départements"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60),
     on_failure_callback=Notification(),
     on_success_callback=Notification(),
@@ -85,7 +84,7 @@ def data_processing_collectivite_territoriale():
     tags=["collectivités", "élus", "conseillers", "epci"],
     default_args=default_args,
     schedule=[dataset_colter],
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60),
     on_failure_callback=Notification(),
     on_success_callback=Notification(),

--- a/workflows/data_pipelines/convcollective/dag.py
+++ b/workflows/data_pipelines/convcollective/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -22,7 +21,7 @@ default_args = {
     tags=["convention collective"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/data_gouv/dag.py
+++ b/workflows/data_pipelines/data_gouv/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import (
@@ -27,7 +26,7 @@ default_args = {
     tags=["publication", "data.gouv"],
     default_args=default_args,
     schedule="0 17 * * *",  # Executes daily at 5 PM
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60 * 3),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/egapro/dag.py
+++ b/workflows/data_pipelines/egapro/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -25,7 +24,7 @@ default_args = {
     tags=["egapro"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/elasticsearch/DAG_index_data.py
+++ b/workflows/data_pipelines/elasticsearch/DAG_index_data.py
@@ -53,7 +53,7 @@ default_args = {
     dag_id=AIRFLOW_ELK_DAG_NAME,
     default_args=default_args,
     schedule=None,  # Triggered by database etl
-    start_date=datetime(2023, 9, 4),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60 * 12),
     tags=["index", "elasticsearch"],
     catchup=False,

--- a/workflows/data_pipelines/elasticsearch/DAG_rollback.py
+++ b/workflows/data_pipelines/elasticsearch/DAG_rollback.py
@@ -28,7 +28,7 @@ default_args = {
     dag_id=AIRFLOW_SNAPSHOT_ROLLBACK_DAG_NAME,
     default_args=default_args,
     schedule=None,
-    start_date=datetime(2024, 1, 1),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60 * 2),
     tags=["siren"],
     catchup=False,

--- a/workflows/data_pipelines/elasticsearch/DAG_snapshot_data.py
+++ b/workflows/data_pipelines/elasticsearch/DAG_snapshot_data.py
@@ -31,7 +31,7 @@ default_args = {
     dag_id=AIRFLOW_SNAPSHOT_DAG_NAME,
     default_args=default_args,
     schedule=None,
-    start_date=datetime(2024, 1, 1),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60 * 2),
     tags=["siren"],
     catchup=False,

--- a/workflows/data_pipelines/ess_france/dag.py
+++ b/workflows/data_pipelines/ess_france/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -27,7 +26,7 @@ default_args = {
     tags=["economie sociale et solidaire", "ESS France"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/etl/dag.py
+++ b/workflows/data_pipelines/etl/dag.py
@@ -131,7 +131,7 @@ default_args = {
     tags=["database", "all-data"],
     default_args=default_args,
     schedule=None,  # triggered by sirene flux dag (everyday at 9 am at the latest)
-    start_date=datetime(2025, 8, 20),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,  # False to ignore past runs

--- a/workflows/data_pipelines/finess/geographique/dag.py
+++ b/workflows/data_pipelines/finess/geographique/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 from data_pipelines_annuaire.config import EMAIL_LIST
 from data_pipelines_annuaire.helpers import Notification
@@ -24,7 +23,7 @@ default_args = {
     tags=["finess", "domaine sanitaire et social"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/finess/juridique/dag.py
+++ b/workflows/data_pipelines/finess/juridique/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 from data_pipelines_annuaire.config import EMAIL_LIST
 from data_pipelines_annuaire.helpers import Notification
@@ -24,7 +23,7 @@ default_args = {
     tags=["finess", "domaine sanitaire et social"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/formation/dag.py
+++ b/workflows/data_pipelines/formation/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -25,7 +24,7 @@ default_args = {
     tags=["qualiopi", "formation"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/marche_inclusion/dag.py
+++ b/workflows/data_pipelines/marche_inclusion/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -22,7 +21,7 @@ default_args = {
     tags=["marche inclusion"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-1),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/metadata/cc/dag.py
+++ b/workflows/data_pipelines/metadata/cc/dag.py
@@ -23,7 +23,7 @@ default_args = {
 
 @dag(
     default_args=default_args,
-    start_date=datetime(2023, 11, 23),
+    start_date=datetime(2026, 1, 1),
     schedule="0 11 2-31/3 * *",  # At 11:00 on every 3rd day-of-month from 2nd through 31st
     catchup=False,
     max_active_runs=1,

--- a/workflows/data_pipelines/patrimoine_vivant/dag.py
+++ b/workflows/data_pipelines/patrimoine_vivant/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -22,7 +21,7 @@ default_args = {
     tags=["entreprise_patrimoine_vivant", "label"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/rge/dag.py
+++ b/workflows/data_pipelines/rge/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -24,7 +23,7 @@ default_args = {
     tags=["reconnu garant de l'environnement", "label", "ademe"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/rne/database/DAG.py
+++ b/workflows/data_pipelines/rne/database/DAG.py
@@ -30,7 +30,7 @@ default_args = {
     tags=["rne", "database"],
     default_args=default_args,
     schedule="0 2 * * *",  # Run daily at 2 am
-    start_date=datetime(2023, 10, 11),
+    start_date=datetime(2026, 1, 1),
     max_active_runs=1,
     dagrun_timeout=timedelta(minutes=(60 * 200)),
     params={},

--- a/workflows/data_pipelines/rne/flux/DAG.py
+++ b/workflows/data_pipelines/rne/flux/DAG.py
@@ -22,7 +22,7 @@ default_args = {
     tags=["rne", "flux"],
     default_args=default_args,
     schedule="0 1 * * *",  # Run every day at 1 AM
-    start_date=datetime(2023, 10, 18),
+    start_date=datetime(2026, 1, 1),
     max_active_runs=1,
     dagrun_timeout=timedelta(days=30),
     params={},

--- a/workflows/data_pipelines/rne/maintenance/DAG.py
+++ b/workflows/data_pipelines/rne/maintenance/DAG.py
@@ -27,7 +27,7 @@ def rename_old_rne_folders():
     description="Delete old object storage files",
     default_args=default_args,
     schedule="0 12 * * *",  # run every day at 12:00 PM (UTC)
-    start_date=datetime(2023, 10, 5),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=(60 * 8)),
     catchup=False,
     max_active_runs=1,  # Allow only one execution at a time

--- a/workflows/data_pipelines/rne/stock/DAG.py
+++ b/workflows/data_pipelines/rne/stock/DAG.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import (
@@ -26,7 +25,7 @@ default_args = {
     tags=["rne", "stock", "download"],
     default_args=default_args,
     schedule=None,  # <- No automatic scheduling
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60 * 18),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/sirene/flux/dag.py
+++ b/workflows/data_pipelines/sirene/flux/dag.py
@@ -25,7 +25,7 @@ default_args = {
     tags=["sirene", "flux"],
     default_args=default_args,
     schedule="30 6 * * *",  # Daily at 6:30 AM
-    start_date=datetime(2025, 8, 20),  # more naive than days_ago()
+    start_date=datetime(2026, 1, 1),  # more naive than days_ago()
     dagrun_timeout=timedelta(minutes=60 * 12),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/sirene/stock/dag.py
+++ b/workflows/data_pipelines/sirene/stock/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -22,7 +21,7 @@ default_args = {
     tags=["sirene", "stock", "historique", "unité légale", "établissement"],
     default_args=default_args,
     schedule="0 0 * * *",  # Run everyday
-    start_date=pendulum.today("UTC").add(days=-1),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60 * 2),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/spectacle/dag.py
+++ b/workflows/data_pipelines/spectacle/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -25,7 +24,7 @@ default_args = {
     tags=["entrepreneur spectacle"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/uai/dag.py
+++ b/workflows/data_pipelines/uai/dag.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
@@ -25,7 +24,7 @@ default_args = {
     tags=["uai", "scolaire"],
     default_args=default_args,
     schedule="0 16 * * *",
-    start_date=pendulum.today("UTC").add(days=-8),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=15),
     params={},
     catchup=False,

--- a/workflows/maintenance/DAG_clean_object_storage.py
+++ b/workflows/maintenance/DAG_clean_object_storage.py
@@ -70,7 +70,7 @@ default_args = {
     description="Delete old object storage files",
     default_args=default_args,
     schedule="0 12 * * *",  # run every day at 12:00 PM (UTC)
-    start_date=datetime(2023, 12, 28),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=30),
     catchup=False,
     max_active_runs=1,  # Allow only one execution at a time

--- a/workflows/maintenance/DAG_flush_and_execute_queries.py
+++ b/workflows/maintenance/DAG_flush_and_execute_queries.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag
 
 from data_pipelines_annuaire.config import (
@@ -26,7 +25,7 @@ default_args = {
     tags=["maintenance", "flush cache and execute queries"],
     default_args=default_args,
     schedule="0 23 10 * *",
-    start_date=pendulum.today("UTC").add(days=-10),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=10),
     params={},
     catchup=False,

--- a/workflows/maintenance/DAG_flush_cache_only.py
+++ b/workflows/maintenance/DAG_flush_cache_only.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pendulum
 from airflow.sdk import dag
 
 from data_pipelines_annuaire.config import (
@@ -26,7 +25,7 @@ default_args = {
     tags=["maintenance", "flush cache only"],
     default_args=default_args,
     schedule="0 23 10 * *",
-    start_date=pendulum.today("UTC").add(days=-10),
+    start_date=datetime(2026, 1, 1),
     dagrun_timeout=timedelta(minutes=5),
     params={},
     catchup=False,


### PR DESCRIPTION
Closes #762 

* Upgrade Airflow version
* Move airflow.Dockerfile from Ansible to search-infra
* Solve 3.2.1 warnings related to `This Dag uses runtime-variable values in Dag construction.`
 
<img width="1021" height="307" alt="image" src="https://github.com/user-attachments/assets/3faa6af4-015e-4dac-a464-2be6e551f1b9" />
 
<img width="1160" height="316" alt="image" src="https://github.com/user-attachments/assets/9675cd45-a012-4354-9833-532a9f3a1257" />

The CI is still using hardcoded versions, we will change this later on once we have a docker registry ready.
It is running on dev-01.