### PR TITLE
feat(bodacc): update radiation logic

### DIFF
--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -679,7 +679,7 @@ def fetch_data_processed_from_huwise(huwise_url: str) -> str:
     response = requests.get(metadata_url, timeout=10)
     response.raise_for_status()
     data = response.json()
-    return data["metas"]["default"]["data_processed"]
+    return data["metas"]["default"]["metadata_processed"]
 
 
 def parse_json_safe(json_str: str) -> dict | None:

--- a/tests/unit_tests/test_bodacc.py
+++ b/tests/unit_tests/test_bodacc.py
@@ -1,9 +1,15 @@
+import json
+
+import pandas as pd
 import pytest
 
 from data_pipelines_annuaire.workflows.data_pipelines.bodacc.utils import (
+    get_previous_ids_to_discard,
+    get_processed_ids_to_discard,
     parse_date_bodacc,
     parse_jugement_json,
     parse_radiation_json,
+    process_discarded_announcements,
 )
 
 # parse_date_bodacc()
@@ -76,3 +82,165 @@ def test_parse_jugement_json_invalid_json():
 
 def test_parse_jugement_json_empty():
     assert parse_jugement_json("") == {"famille": "", "nature": "", "date": ""}
+
+
+# Helper to build parutionavisprecedent JSON
+
+
+def _avis_precedent(num_parution: str, num_annonce: str) -> str:
+    return json.dumps(
+        {
+            "nomPublication": "BODACC A",
+            "numeroParution": num_parution,
+            "numeroAnnonce": num_annonce,
+        }
+    )
+
+
+# get_discarded_ids()
+
+
+def test_get_discarded_ids_annulation():
+    df = pd.DataFrame(
+        {
+            "id": ["A20241000", "A20242000"],
+            "typeavis": ["annonce", "annulation"],
+            "parutionavisprecedent": ["", _avis_precedent("2024", "1000")],
+        }
+    )
+    assert get_previous_ids_to_discard(df) == {"A20241000"}
+
+
+def test_get_discarded_ids_rectificatif():
+    df = pd.DataFrame(
+        {
+            "id": ["A20241000", "A20243000"],
+            "typeavis": ["annonce", "rectificatif"],
+            "parutionavisprecedent": ["", _avis_precedent("2024", "1000")],
+        }
+    )
+    assert get_previous_ids_to_discard(df) == {"A20241000"}
+
+
+def test_get_discarded_ids_both():
+    df = pd.DataFrame(
+        {
+            "id": ["A20241000", "A20242000", "A20243000"],
+            "typeavis": ["annonce", "annulation", "rectificatif"],
+            "parutionavisprecedent": [
+                "",
+                _avis_precedent("2024", "1000"),
+                _avis_precedent("2024", "2000"),
+            ],
+        }
+    )
+    discarded = get_previous_ids_to_discard(df)
+    assert discarded == {"A20241000", "A20242000"}
+
+
+# get_ids_to_discard()
+
+
+def test_get_ids_to_discard_annulation():
+    df = pd.DataFrame(
+        {
+            "id": ["A20241000", "A20242000"],
+            "typeavis": ["annonce", "annulation"],
+            "parutionavisprecedent": ["", _avis_precedent("2024", "1000")],
+        }
+    )
+    assert get_processed_ids_to_discard(df) == {"A20242000"}
+
+
+def test_get_ids_to_discard_radiation_doffice():
+    radiation_doffice = json.dumps({"commentaire": "Rapport de radiation d'office"})
+    df = pd.DataFrame(
+        {
+            "id": ["A20241000", "A20243000"],
+            "typeavis": ["annonce", "rectificatif"],
+            "parutionavisprecedent": ["", _avis_precedent("2024", "1000")],
+            "radiationaurcs": ["", radiation_doffice],
+        }
+    )
+    assert get_processed_ids_to_discard(df) == {"A20243000"}
+
+
+def test_get_ids_to_discard_keeps_normal_rectificatif():
+    normal_radiation = json.dumps({"dateCessationActivitePP": "2024-01-15"})
+    df = pd.DataFrame(
+        {
+            "id": ["A20241000", "A20243000"],
+            "typeavis": ["annonce", "rectificatif"],
+            "parutionavisprecedent": ["", _avis_precedent("2024", "1000")],
+            "radiationaurcs": ["", normal_radiation],
+        }
+    )
+    assert get_processed_ids_to_discard(df) == set()
+
+
+# process_discarded_announcements()
+
+
+def test_filter_discarded_removes_annulation_and_its_target():
+    df = pd.DataFrame(
+        {
+            "id": ["A20241000", "A20242000"],
+            "typeavis": ["annonce", "annulation"],
+            "parutionavisprecedent": ["", _avis_precedent("2024", "1000")],
+        }
+    )
+    result = process_discarded_announcements(df)
+    assert result["id"].tolist() == []
+
+
+def test_filter_discarded_removes_rectified_but_keeps_rectificatif():
+    df = pd.DataFrame(
+        {
+            "id": ["A20241000", "A20243000"],
+            "typeavis": ["annonce", "rectificatif"],
+            "parutionavisprecedent": ["", _avis_precedent("2024", "1000")],
+        }
+    )
+    result = process_discarded_announcements(df)
+    assert result["id"].tolist() == ["A20243000"]
+    assert result["typeavis"].tolist() == ["rectificatif"]
+
+
+def test_filter_discarded_keeps_unrelated_annonce():
+    df = pd.DataFrame(
+        {
+            "id": ["A20241000", "A20245000", "A20243000"],
+            "typeavis": ["annonce", "annonce", "rectificatif"],
+            "parutionavisprecedent": ["", "", _avis_precedent("2024", "1000")],
+        }
+    )
+    result = process_discarded_announcements(df)
+    assert set(result["id"].tolist()) == {"A20245000", "A20243000"}
+
+
+def test_filter_discarded_removes_rectificatif_radiation_doffice():
+    radiation_doffice = json.dumps({"commentaire": "Rapport de radiation d'office"})
+    df = pd.DataFrame(
+        {
+            "id": ["A20241000", "A20243000"],
+            "typeavis": ["annonce", "rectificatif"],
+            "parutionavisprecedent": ["", _avis_precedent("2024", "1000")],
+            "radiationaurcs": ["", radiation_doffice],
+        }
+    )
+    result = process_discarded_announcements(df)
+    assert result["id"].tolist() == []
+
+
+def test_filter_discarded_keeps_normal_rectificatif_with_radiationaurcs():
+    normal_radiation = json.dumps({"dateCessationActivitePP": "2024-01-15"})
+    df = pd.DataFrame(
+        {
+            "id": ["A20241000", "A20243000"],
+            "typeavis": ["annonce", "rectificatif"],
+            "parutionavisprecedent": ["", _avis_precedent("2024", "1000")],
+            "radiationaurcs": ["", normal_radiation],
+        }
+    )
+    result = process_discarded_announcements(df)
+    assert result["id"].tolist() == ["A20243000"]

--- a/workflows/data_pipelines/bodacc/processor.py
+++ b/workflows/data_pipelines/bodacc/processor.py
@@ -12,10 +12,10 @@ from data_pipelines_annuaire.workflows.data_pipelines.bodacc.config import (
 )
 from data_pipelines_annuaire.workflows.data_pipelines.bodacc.utils import (
     extract_siren_from_registre,
-    filter_cancelled_announcements,
     is_cloture,
     parse_jugement_json,
     parse_radiation_json,
+    process_discarded_announcements,
 )
 
 
@@ -168,7 +168,7 @@ class BodaccProcessor(DataProcessor):
         logging.info(f"Loaded {total_rows} radiation rows")
 
         # Filtrer les annulations
-        df_full = filter_cancelled_announcements(df_full)
+        df_full = process_discarded_announcements(df_full)
         logging.info(f"After filtering cancellations: {len(df_full)} rows")
 
         # Traiter par chunks pour la mémoire
@@ -242,7 +242,7 @@ class BodaccProcessor(DataProcessor):
         logging.info(f"Loaded {total_rows} procedure rows")
 
         # Filtrer les annulations et rétractations
-        df_full = filter_cancelled_announcements(df_full)
+        df_full = process_discarded_announcements(df_full)
         logging.info(f"After filtering cancellations: {len(df_full)} rows")
 
         # Traiter par chunks pour la mémoire

--- a/workflows/data_pipelines/bodacc/utils.py
+++ b/workflows/data_pipelines/bodacc/utils.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 
 import pandas as pd
@@ -135,6 +136,17 @@ def is_retractation(famille: str) -> bool:
     return any(kw in famille_lower for kw in FAMILLES_ANNULATION)
 
 
+def is_rapport_de_radiation_doffice(radiationaurcs_str: str) -> bool:
+    """
+    Vérifie si le champ radiationaurcs indique un rapport de radiation d'office.
+    Un rapport de radiation d'office correspond à l'annulation d'une radiation.
+    """
+    data = parse_json_safe(radiationaurcs_str)
+    if not data:
+        return False
+    return data.get("commentaire", "") == "Rapport de radiation d'office"
+
+
 def build_bodacc_id(
     code_publication: str, numero_parution: str | int, numero_annonce: str | int
 ) -> str | None:
@@ -144,8 +156,8 @@ def build_bodacc_id(
     return None
 
 
-def extract_cancelled_id_from_avis_precedent(avis_precedent_str: str) -> str | None:
-    """Extrait l'ID de l'annonce annulée depuis le champs Json parutionavisprecedent."""
+def extract_id_from_avis_precedent(avis_precedent_str: str) -> str | None:
+    """Extrait l'ID de l'annonce annulée ou rectifiée depuis le champs Json parutionavisprecedent."""
     avis = parse_json_safe(avis_precedent_str)
     if not avis:
         return None
@@ -156,20 +168,29 @@ def extract_cancelled_id_from_avis_precedent(avis_precedent_str: str) -> str | N
     )
 
 
-def get_cancelled_ids(df: pd.DataFrame) -> set:
-    """Extrait les IDs des annonces annulées (annulations + rétractations)."""
-    cancelled_ids = set()
+def get_previous_ids_to_discard(df: pd.DataFrame) -> set:
+    """Extrait les IDs des annonces précédentes annulées, rectifiées ou rétractées."""
+    discarded_ids = set()
 
-    # Annulations explicites
+    # Annulation explicite de l'avis précédent
     annulations = df[df["typeavis"] == "annulation"]
     if not annulations.empty:
         ids_from_annulations = annulations["parutionavisprecedent"].apply(
-            extract_cancelled_id_from_avis_precedent
+            extract_id_from_avis_precedent
         )
-        cancelled_ids.update(ids_from_annulations.dropna())
+        discarded_ids.update(ids_from_annulations.dropna())
+
+    # Rectificatif (remplacement) de l'annonce précédente
+    rectificatifs = df[df["typeavis"] == "rectificatif"]
+    if not rectificatifs.empty:
+        ids_from_rectificatifs = rectificatifs["parutionavisprecedent"].apply(
+            extract_id_from_avis_precedent
+        )
+        discarded_ids.update(ids_from_rectificatifs.dropna())
 
     # Rétractations sur tierce opposition
     # S'applique aux procédures collectives et non aux radiations
+    # Le filtre sur jugement permet d'identifier les procédures collectives des radiations
     if "jugement" in df.columns:
         familles = df["jugement"].apply(
             lambda x: (
@@ -179,38 +200,63 @@ def get_cancelled_ids(df: pd.DataFrame) -> set:
         retractations = df[familles.apply(is_retractation)]
         if not retractations.empty:
             ids_from_retractations = retractations["parutionavisprecedent"].apply(
-                extract_cancelled_id_from_avis_precedent
+                extract_id_from_avis_precedent
             )
-            cancelled_ids.update(ids_from_retractations.dropna())
+            discarded_ids.update(ids_from_retractations.dropna())
 
-    return cancelled_ids
+    return discarded_ids
 
 
-def filter_cancelled_announcements(df: pd.DataFrame) -> pd.DataFrame:
+def get_processed_ids_to_discard(df: pd.DataFrame) -> set:
     """
-    Exclut :
-        - les annonces annulées
-        - les avis d'annulations
-        - les rétractations
+    Extrait les IDs des :
+       - avis d'annulation,
+       - rectificatifs avec rapport de radiation d'office,
+       - jugements de rétractations.
     """
-    cancelled_ids = get_cancelled_ids(df)
+    ids_to_discard = set()
 
-    # Exclut les annonces annulées
-    df = df[~df["id"].isin(cancelled_ids)]
+    # Avis d'annulations
+    annulations = df[df["typeavis"] == "annulation"]
+    ids_to_discard.update(annulations["id"].dropna())
 
-    # Exclut les avis d'annulations
-    df = df[df["typeavis"] != "annulation"]
+    # Rectificatifs de type "radiation d'office" (équivalent annulation)
+    if "radiationaurcs" in df.columns:
+        is_rectificatif = df["typeavis"] == "rectificatif"
+        is_rad_doffice = df["radiationaurcs"].apply(is_rapport_de_radiation_doffice)
+        ids_to_discard.update(df.loc[is_rectificatif & is_rad_doffice, "id"].dropna())
 
-    # Exclut aussi les rétractations elles-mêmes (seulement si colonne jugement existe)
+    # Rétractations sur tierce opposition
+    # Le filtre sur jugement permet d'identifier les procédures collectives des radiations
     if "jugement" in df.columns:
-        df = df.copy()
-        df["_famille"] = df["jugement"].apply(
+        familles = df["jugement"].apply(
             lambda x: (
                 parse_json_safe(x).get("famille", "") if parse_json_safe(x) else ""
             )
         )
-        df = df[~df["_famille"].apply(is_retractation)]
-        df = df.drop(columns=["_famille"])
+        retractations = df[familles.apply(is_retractation)]
+        ids_to_discard.update(retractations["id"].dropna())
+
+    return ids_to_discard
+
+
+def process_discarded_announcements(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Exclut :
+        - les annonces annulées,
+        - les annonces rectifiées,
+        - les avis d'annulations,
+        - les rétractations.
+    Les rectificatifs sont conservés car ils portent la valeur à jour.
+    """
+
+    logging.info("Supprime les annonces annulées ou remplacées")
+    discarded_ids = get_previous_ids_to_discard(df)
+    df = df[~df["id"].isin(discarded_ids)]
+
+    logging.info("Supprime les annonces qui annulent les annonces précédentes")
+    ids_to_discard = get_processed_ids_to_discard(df)
+    df = df[~df["id"].isin(ids_to_discard)]
 
     return df
 

--- a/workflows/data_pipelines/bodacc/utils.py
+++ b/workflows/data_pipelines/bodacc/utils.py
@@ -157,7 +157,7 @@ def build_bodacc_id(
 
 
 def extract_id_from_avis_precedent(avis_precedent_str: str) -> str | None:
-    """Extrait l'ID de l'annonce annulée ou rectifiée depuis le champs Json parutionavisprecedent."""
+    """Extrait l'ID de l'annonce annulée ou rectifiée depuis le champ json parutionavisprecedent."""
     avis = parse_json_safe(avis_precedent_str)
     if not avis:
         return None


### PR DESCRIPTION
Related to #746 

### Changement de la date de mise à jour

La DILA nous a  dit que le fichier était mis à jour chaque jour ouvré.
Au vu des changements de date que j'observe sur le jeu de données, il faut donc utiliser la date `metadata_processed` et non `data_processed` pour identifier la dernière mise à jour du fichier depuis l'API Huwise.

### Appliquer les correctifs d'annonces

Quand l'avis le plus récent est un correctif : 

1. Supprime l'avis précédent référé par l'avis correctif (champs `parutionavisprecedent`)

> [!TIP]
> À noter que ce changement s'applique aussi automatiquement aux annonces rectificatives des procédures collectives qui partagent la même logique dans le code sur l'identification du dernier avis.

2. Et pour les radiations seulement, on supprime aussi l'avis correctif lui-même si celui ci contient un commentaire `Rapport de radiation d'office` car il s'agit alors d'une suppression de l'avis précédent et non d'un correctif qui vient remplacer l'ancien contenu.

> [!TIP]
> À noter que la logique des avis d'annulations est similaire à celle des correctifs sauf que l'ensemble des avis d'annulations sont aussi supprimés pour pouvoir identifier les vrais derniers avis à considérer.

### Autres

De plus `cancel` a été renommé en `discard` pour que ça soit plus générique et que cela inclut les correctifs.

Live on dev-01.