### PR TITLE
feat(bodacc): v1 of procédures collectives and new bodacc format in index

### DIFF
--- a/tests/e2e_tests/test_api.py
+++ b/tests/e2e_tests/test_api.py
@@ -909,29 +909,3 @@ def test_a_aide_ademe(api_response_tester):
     path = "/search?q=054392758"
     api_response_tester.assert_api_response_code_200(path)
     api_response_tester.test_field_value(path, 0, "complements.a_aide_ademe", True)
-
-
-def test_bodacc(api_response_tester):
-    # SIREN 552032534 : entreprise active sans radiation ni procédure collective
-    path = "/search?q=552032534&include_admin=bodacc"
-    api_response_tester.assert_api_response_code_200(path)
-
-    api_response_tester.test_field_value(path, 0, "bodacc.radiation", None)
-    api_response_tester.test_field_value(path, 0, "bodacc.procedure_collective", None)
-
-    # SIREN 442750196 : entreprise avec une date de radiation
-    path = "/search?q=442750196&include_admin=bodacc"
-    api_response_tester.assert_api_response_code_200(path)
-
-    api_response_tester.test_field_value(path, 0, "bodacc.radiation.est_radie", True)
-    api_response_tester.test_field_value(path, 0, "bodacc.radiation.date", "2014-06-01")
-    api_response_tester.test_field_value(path, 0, "bodacc.procedure_collective", None)
-
-    # SIREN 909324055 : entreprise en procédure collective
-    path = "/search?q=909324055&include_admin=bodacc"
-    api_response_tester.assert_api_response_code_200(path)
-
-    api_response_tester.test_field_not_none(path, 0, "bodacc.procedure_collective.date")
-    api_response_tester.test_field_not_none(
-        path, 0, "bodacc.procedure_collective.statut"
-    )

--- a/tests/e2e_tests/test_api.py
+++ b/tests/e2e_tests/test_api.py
@@ -916,37 +916,22 @@ def test_bodacc(api_response_tester):
     path = "/search?q=552032534&include_admin=bodacc"
     api_response_tester.assert_api_response_code_200(path)
 
-    bodacc_data = {
-        "radiation_rcs": False,
-        "radiation_rcs_date": None,
-        "procedure_collective_date_jugement": None,
-        "procedure_collective_nature": None,
-    }
-
-    for field, expected_value in bodacc_data.items():
-        api_response_tester.test_field_value(path, 0, f"bodacc.{field}", expected_value)
+    api_response_tester.test_field_value(path, 0, "bodacc.radiation", None)
+    api_response_tester.test_field_value(path, 0, "bodacc.procedure_collective", None)
 
     # SIREN 442750196 : entreprise avec une date de radiation
     path = "/search?q=442750196&include_admin=bodacc"
     api_response_tester.assert_api_response_code_200(path)
 
-    bodacc_data = {
-        "radiation_rcs": True,
-        "radiation_rcs_date": "2014-06-01",
-        "procedure_collective_date_jugement": None,
-        "procedure_collective_nature": None,
-    }
-
-    for field, expected_value in bodacc_data.items():
-        api_response_tester.test_field_value(path, 0, f"bodacc.{field}", expected_value)
+    api_response_tester.test_field_value(path, 0, "bodacc.radiation.est_radie", True)
+    api_response_tester.test_field_value(path, 0, "bodacc.radiation.date", "2014-06-01")
+    api_response_tester.test_field_value(path, 0, "bodacc.procedure_collective", None)
 
     # SIREN 909324055 : entreprise en procédure collective
     path = "/search?q=909324055&include_admin=bodacc"
     api_response_tester.assert_api_response_code_200(path)
 
+    api_response_tester.test_field_not_none(path, 0, "bodacc.procedure_collective.date")
     api_response_tester.test_field_not_none(
-        path, 0, "bodacc.procedure_collective_date_jugement"
-    )
-    api_response_tester.test_field_not_none(
-        path, 0, "bodacc.procedure_collective_nature"
+        path, 0, "bodacc.procedure_collective.statut"
     )

--- a/tests/unit_tests/test_bodacc.py
+++ b/tests/unit_tests/test_bodacc.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from data_pipelines_annuaire.workflows.data_pipelines.bodacc.utils import (
+    fix_mojibake,
     get_previous_ids_to_discard,
     get_processed_ids_to_discard,
     is_cloture,
@@ -12,6 +13,25 @@ from data_pipelines_annuaire.workflows.data_pipelines.bodacc.utils import (
     parse_radiation_json,
     process_discarded_announcements,
 )
+
+# fix_mojibake()
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        ("clÃ´ture", "clôture"),
+        ("procÃ©dure", "procédure"),
+        ("DÃ©pÃ´t de l'Ã©tat des crÃ©ances", "Dépôt de l'état des créances"),
+        ("ArrÃªt de la cour d'appel", "Arrêt de la cour d'appel"),
+        ("Jugement prononÃ§ant", "Jugement prononçant"),
+        ("Jugement de clôture", "Jugement de clôture"),
+        ("", ""),
+    ],
+)
+def test_fix_mojibake(input, expected):
+    assert fix_mojibake(input) == expected
+
 
 # parse_date_bodacc()
 

--- a/tests/unit_tests/test_bodacc.py
+++ b/tests/unit_tests/test_bodacc.py
@@ -83,6 +83,7 @@ def test_parse_jugement_json_full():
     assert parse_jugement_json(data) == {
         "famille": "Ouverture",
         "nature": "Redressement judiciaire",
+        "complementJugement": "",
         "date": "2024-07-24",
     }
 
@@ -94,15 +95,37 @@ def test_parse_jugement_json_date_converted():
 
 
 def test_parse_jugement_json_missing_keys():
-    assert parse_jugement_json("{}") == {"famille": "", "nature": "", "date": ""}
+    assert parse_jugement_json("{}") == {
+        "famille": "",
+        "nature": "",
+        "complementJugement": "",
+        "date": "",
+    }
 
 
 def test_parse_jugement_json_invalid_json():
-    assert parse_jugement_json("not json") == {"famille": "", "nature": "", "date": ""}
+    assert parse_jugement_json("not json") == {
+        "famille": "",
+        "nature": "",
+        "complementJugement": "",
+        "date": "",
+    }
 
 
 def test_parse_jugement_json_empty():
-    assert parse_jugement_json("") == {"famille": "", "nature": "", "date": ""}
+    assert parse_jugement_json("") == {
+        "famille": "",
+        "nature": "",
+        "complementJugement": "",
+        "date": "",
+    }
+
+
+def test_parse_jugement_json_fixes_mojibake():
+    data = '{"famille": "Jugement de clÃ´ture", "nature": "Jugement de clÃ´ture pour insuffisance d\'actif", "date": "2024-01-15"}'
+    result = parse_jugement_json(data)
+    assert result["famille"] == "Jugement de clôture"
+    assert result["nature"] == "Jugement de clôture pour insuffisance d'actif"
 
 
 # Helper to build parutionavisprecedent JSON

--- a/tests/unit_tests/test_bodacc.py
+++ b/tests/unit_tests/test_bodacc.py
@@ -297,12 +297,12 @@ def test_filter_discarded_keeps_normal_rectificatif_with_radiationaurcs():
 
 def _apply_expiration_logic(df: pd.DataFrame) -> pd.DataFrame:
     """Reproduit la logique d'expiration de _process_procedures_collectives."""
-    df["procedure_collective_date_jugement"] = pd.to_datetime(
-        df["procedure_collective_date_jugement"], errors="coerce", format="%Y-%m-%d"
+    df["procedure_collective_date"] = pd.to_datetime(
+        df["procedure_collective_date"], errors="coerce", format="%Y-%m-%d"
     )
     df["is_cloture"] = df["procedure_collective_famille"].apply(is_cloture)
     ten_years_ago = pd.Timestamp.now() - pd.DateOffset(years=10)
-    df["is_expired"] = df["procedure_collective_date_jugement"] < ten_years_ago
+    df["is_expired"] = df["procedure_collective_date"] < ten_years_ago
     df["procedure_collective_nature"] = df.apply(
         lambda row: (
             ""
@@ -319,7 +319,7 @@ def test_procedure_older_than_10_years_has_no_nature():
         {
             "procedure_collective_famille": ["Ouverture"],
             "procedure_collective_nature": ["Redressement judiciaire"],
-            "procedure_collective_date_jugement": ["2010-01-01"],
+            "procedure_collective_date": ["2010-01-01"],
         }
     )
     result = _apply_expiration_logic(df)
@@ -331,7 +331,7 @@ def test_recent_procedure_keeps_nature():
         {
             "procedure_collective_famille": ["Ouverture"],
             "procedure_collective_nature": ["Redressement judiciaire"],
-            "procedure_collective_date_jugement": ["2024-01-01"],
+            "procedure_collective_date": ["2024-01-01"],
         }
     )
     result = _apply_expiration_logic(df)
@@ -343,7 +343,7 @@ def test_cloture_procedure_has_no_nature_regardless_of_age():
         {
             "procedure_collective_famille": ["Jugement de clôture"],
             "procedure_collective_nature": ["Liquidation judiciaire"],
-            "procedure_collective_date_jugement": ["2024-01-01"],
+            "procedure_collective_date": ["2024-01-01"],
         }
     )
     result = _apply_expiration_logic(df)

--- a/tests/unit_tests/test_bodacc.py
+++ b/tests/unit_tests/test_bodacc.py
@@ -4,10 +4,12 @@ import pandas as pd
 import pytest
 
 from data_pipelines_annuaire.workflows.data_pipelines.bodacc.utils import (
+    apply_procedure_collective_rules,
     fix_mojibake,
     get_previous_ids_to_discard,
     get_processed_ids_to_discard,
     is_cloture,
+    load_procedure_collective_rules,
     parse_date_bodacc,
     parse_jugement_json,
     parse_radiation_json,
@@ -346,3 +348,67 @@ def test_cloture_procedure_has_no_nature_regardless_of_age():
     )
     result = _apply_expiration_logic(df)
     assert result["procedure_collective_nature"].iloc[0] == ""
+
+
+# apply_procedure_collective_rules()
+
+
+@pytest.fixture
+def rules():
+    return load_procedure_collective_rules()
+
+
+def test_rules_liquidation_judiciaire(rules):
+    statut = apply_procedure_collective_rules(
+        "Jugement d'ouverture de liquidation judiciaire", "", rules
+    )
+    assert statut == "liquidation_judiciaire"
+
+
+def test_rules_redressement_judiciaire(rules):
+    statut = apply_procedure_collective_rules(
+        "Jugement d'ouverture d'une procédure de redressement judiciaire", "", rules
+    )
+    assert statut == "redressement_judiciaire"
+
+
+def test_rules_sauvegarde(rules):
+    statut = apply_procedure_collective_rules(
+        "Jugement d'ouverture d'une procédure de sauvegarde", "", rules
+    )
+    assert statut == "sauvegarde"
+
+
+def test_rules_cloture_returns_none(rules):
+    statut = apply_procedure_collective_rules(
+        "Jugement de clôture pour insuffisance d'actif", "", rules
+    )
+    assert statut is None
+
+
+def test_rules_autre_jugement_with_complement(rules):
+    statut = apply_procedure_collective_rules(
+        "Autre jugement prononçant",
+        "la clôture de la procédure pour insuffisance d'actif",
+        rules,
+    )
+    assert statut is None
+
+
+def test_rules_autre_jugement_with_complement_liquidation(rules):
+    statut = apply_procedure_collective_rules(
+        "Autre jugement prononçant",
+        "l'ouverture d'une procédure de liquidation judiciaire",
+        rules,
+    )
+    assert statut == "liquidation_judiciaire"
+
+
+def test_rules_unknown_nature_returns_none(rules):
+    statut = apply_procedure_collective_rules("Nature inconnue", "", rules)
+    assert statut is None
+
+
+def test_rules_empty_nature():
+    rules = load_procedure_collective_rules()
+    assert apply_procedure_collective_rules("", "", rules) is None

--- a/tests/unit_tests/test_bodacc.py
+++ b/tests/unit_tests/test_bodacc.py
@@ -6,6 +6,7 @@ import pytest
 from data_pipelines_annuaire.workflows.data_pipelines.bodacc.utils import (
     get_previous_ids_to_discard,
     get_processed_ids_to_discard,
+    is_cloture,
     parse_date_bodacc,
     parse_jugement_json,
     parse_radiation_json,
@@ -244,3 +245,61 @@ def test_filter_discarded_keeps_normal_rectificatif_with_radiationaurcs():
     )
     result = process_discarded_announcements(df)
     assert result["id"].tolist() == ["A20243000"]
+
+
+# Expiration des procédures > 10 ans
+
+
+def _apply_expiration_logic(df: pd.DataFrame) -> pd.DataFrame:
+    """Reproduit la logique d'expiration de _process_procedures_collectives."""
+    df["procedure_collective_date_jugement"] = pd.to_datetime(
+        df["procedure_collective_date_jugement"], errors="coerce", format="%Y-%m-%d"
+    )
+    df["is_cloture"] = df["procedure_collective_famille"].apply(is_cloture)
+    ten_years_ago = pd.Timestamp.now() - pd.DateOffset(years=10)
+    df["is_expired"] = df["procedure_collective_date_jugement"] < ten_years_ago
+    df["procedure_collective_nature"] = df.apply(
+        lambda row: (
+            ""
+            if row["is_cloture"] or row["is_expired"]
+            else row["procedure_collective_nature"]
+        ),
+        axis=1,
+    )
+    return df
+
+
+def test_procedure_older_than_10_years_has_no_nature():
+    df = pd.DataFrame(
+        {
+            "procedure_collective_famille": ["Ouverture"],
+            "procedure_collective_nature": ["Redressement judiciaire"],
+            "procedure_collective_date_jugement": ["2010-01-01"],
+        }
+    )
+    result = _apply_expiration_logic(df)
+    assert result["procedure_collective_nature"].iloc[0] == ""
+
+
+def test_recent_procedure_keeps_nature():
+    df = pd.DataFrame(
+        {
+            "procedure_collective_famille": ["Ouverture"],
+            "procedure_collective_nature": ["Redressement judiciaire"],
+            "procedure_collective_date_jugement": ["2024-01-01"],
+        }
+    )
+    result = _apply_expiration_logic(df)
+    assert result["procedure_collective_nature"].iloc[0] == "Redressement judiciaire"
+
+
+def test_cloture_procedure_has_no_nature_regardless_of_age():
+    df = pd.DataFrame(
+        {
+            "procedure_collective_famille": ["Jugement de clôture"],
+            "procedure_collective_nature": ["Liquidation judiciaire"],
+            "procedure_collective_date_jugement": ["2024-01-01"],
+        }
+    )
+    result = _apply_expiration_logic(df)
+    assert result["procedure_collective_nature"].iloc[0] == ""

--- a/workflows/data_pipelines/bodacc/config.py
+++ b/workflows/data_pipelines/bodacc/config.py
@@ -33,6 +33,7 @@ BODACC_CONFIG = DataSourceConfig(
             radiation_rcs_date_publication DATE,
             procedure_collective_id TEXT,
             procedure_collective_nature TEXT,
+            procedure_collective_complement_jugement TEXT,
             procedure_collective_date_jugement DATE,
             procedure_collective_date_publication DATE,
 

--- a/workflows/data_pipelines/bodacc/config.py
+++ b/workflows/data_pipelines/bodacc/config.py
@@ -27,15 +27,15 @@ BODACC_CONFIG = DataSourceConfig(
         CREATE TABLE IF NOT EXISTS bodacc
         (
             siren TEXT PRIMARY KEY,
-            radiation_rcs_id TEXT,
-            radiation_rcs INTEGER,
-            radiation_rcs_date DATE,
-            radiation_rcs_date_publication DATE,
-            procedure_collective_id TEXT,
+            radiation_id_annonce TEXT,
+            radiation_est_radie INTEGER,
+            radiation_date DATE,
+            radiation_date_publication DATE,
+            procedure_collective_id_annonce TEXT,
             procedure_collective_statut TEXT,
             procedure_collective_nature TEXT,
-            procedure_collective_complement_jugement TEXT,
-            procedure_collective_date_jugement DATE,
+            procedure_collective_complement TEXT,
+            procedure_collective_date DATE,
             procedure_collective_date_publication DATE,
 
             procedure_collective_cloturee_nature TEXT

--- a/workflows/data_pipelines/bodacc/config.py
+++ b/workflows/data_pipelines/bodacc/config.py
@@ -32,6 +32,7 @@ BODACC_CONFIG = DataSourceConfig(
             radiation_rcs_date DATE,
             radiation_rcs_date_publication DATE,
             procedure_collective_id TEXT,
+            procedure_collective_statut TEXT,
             procedure_collective_nature TEXT,
             procedure_collective_complement_jugement TEXT,
             procedure_collective_date_jugement DATE,

--- a/workflows/data_pipelines/bodacc/processor.py
+++ b/workflows/data_pipelines/bodacc/processor.py
@@ -299,23 +299,41 @@ class BodaccProcessor(DataProcessor):
         # Déterminer si la procédure la plus récente est une clôture
         df["is_cloture"] = df["procedure_collective_famille"].apply(is_cloture)
 
+        ten_years_ago = pd.Timestamp.now() - pd.DateOffset(years=10)
+        df["is_expired"] = df["procedure_collective_date_jugement"] < ten_years_ago
+
         # Créer les colonnes finales
         df["procedure_collective_cloturee_nature"] = df.apply(
             lambda row: row["procedure_collective_nature"] if row["is_cloture"] else "",
             axis=1,
         )
         df["procedure_collective_nature_finale"] = df.apply(
-            lambda row: "" if row["is_cloture"] else row["procedure_collective_nature"],
+            lambda row: (
+                ""
+                if row["is_cloture"] or row["is_expired"]
+                else row["procedure_collective_nature"]
+            ),
             axis=1,
         )
 
         # Renommer pour l'export
         df["procedure_collective_nature"] = df["procedure_collective_nature_finale"]
 
+        # Effacer le statut pour les procédures clôturées ou expirées
+        df["procedure_collective_statut"] = df.apply(
+            lambda row: (
+                ""
+                if row["is_cloture"] or row["is_expired"]
+                else row["procedure_collective_statut"] or ""
+            ),
+            axis=1,
+        )
+
         logging.info(
             f"Procedures: {len(df)} unique SIRENs, "
             f"{df['is_cloture'].sum()} clôturées, "
-            f"{(~df['is_cloture']).sum()} en cours"
+            f"{(~df['is_cloture'] & df['is_expired']).sum()} expirées (>10 ans), "
+            f"{(~df['is_cloture'] & ~df['is_expired']).sum()} en cours"
         )
 
         return df[

--- a/workflows/data_pipelines/bodacc/processor.py
+++ b/workflows/data_pipelines/bodacc/processor.py
@@ -87,6 +87,9 @@ def process_procedure_chunk(chunk: pd.DataFrame) -> pd.DataFrame:
     chunk["procedure_collective_nature"] = chunk["jugement_parsed"].apply(
         lambda x: x.get("nature", "") if x else ""
     )
+    chunk["procedure_collective_complement_jugement"] = chunk["jugement_parsed"].apply(
+        lambda x: x.get("complementJugement", "") if x else ""
+    )
     chunk["procedure_collective_date_jugement"] = chunk["jugement_parsed"].apply(
         lambda x: x.get("date", "") if x else ""
     )
@@ -100,6 +103,7 @@ def process_procedure_chunk(chunk: pd.DataFrame) -> pd.DataFrame:
             "procedure_collective_id",
             "procedure_collective_famille",
             "procedure_collective_nature",
+            "procedure_collective_complement_jugement",
             "procedure_collective_date_jugement",
             "procedure_collective_date_publication",
         ]
@@ -259,6 +263,7 @@ class BodaccProcessor(DataProcessor):
                     "siren",
                     "procedure_collective_id",
                     "procedure_collective_nature",
+                    "procedure_collective_complement_jugement",
                     "procedure_collective_date_jugement",
                     "procedure_collective_date_publication",
                     "procedure_collective_cloturee_nature",
@@ -341,6 +346,7 @@ class BodaccProcessor(DataProcessor):
                 "siren",
                 "procedure_collective_id",
                 "procedure_collective_nature",
+                "procedure_collective_complement_jugement",
                 "procedure_collective_date_jugement",
                 "procedure_collective_date_publication",
                 "procedure_collective_cloturee_nature",

--- a/workflows/data_pipelines/bodacc/processor.py
+++ b/workflows/data_pipelines/bodacc/processor.py
@@ -11,8 +11,10 @@ from data_pipelines_annuaire.workflows.data_pipelines.bodacc.config import (
     BODACC_CONFIG,
 )
 from data_pipelines_annuaire.workflows.data_pipelines.bodacc.utils import (
+    apply_procedure_collective_rules,
     extract_siren_from_registre,
     is_cloture,
+    load_procedure_collective_rules,
     parse_jugement_json,
     parse_radiation_json,
     process_discarded_announcements,
@@ -78,7 +80,7 @@ def process_procedure_chunk(chunk: pd.DataFrame) -> pd.DataFrame:
     )
 
     # Exclure les familles non pertinentes
-    familles_exclues = ["Avis de dépôt", "Extrait de jugement"]
+    familles_exclues = ["Avis de dépôt", "Extrait de jugement", "Loi de 1967"]
     chunk = chunk[~chunk["procedure_collective_famille"].isin(familles_exclues)]
 
     if chunk.empty:
@@ -262,6 +264,7 @@ class BodaccProcessor(DataProcessor):
                 columns=[
                     "siren",
                     "procedure_collective_id",
+                    "procedure_collective_statut",
                     "procedure_collective_nature",
                     "procedure_collective_complement_jugement",
                     "procedure_collective_date_jugement",
@@ -272,6 +275,17 @@ class BodaccProcessor(DataProcessor):
 
         # Concaténer tous les chunks
         df = pd.concat(chunks_processed, ignore_index=True)
+
+        # Appliquer les règles de classification
+        rules = load_procedure_collective_rules()
+        df["procedure_collective_statut"] = df.apply(
+            lambda row: apply_procedure_collective_rules(
+                row["procedure_collective_nature"],
+                row["procedure_collective_complement_jugement"],
+                rules,
+            ),
+            axis=1,
+        )
 
         # Environ 5 dates de procédures collectives avec des dates absurdes comme 0009-12-02 ou 5025-05-27
         # Ces "erreurs" sont ignorées lors des conversions en datetime
@@ -345,6 +359,7 @@ class BodaccProcessor(DataProcessor):
             [
                 "siren",
                 "procedure_collective_id",
+                "procedure_collective_statut",
                 "procedure_collective_nature",
                 "procedure_collective_complement_jugement",
                 "procedure_collective_date_jugement",

--- a/workflows/data_pipelines/bodacc/processor.py
+++ b/workflows/data_pipelines/bodacc/processor.py
@@ -38,21 +38,21 @@ def process_radiation_chunk(chunk: pd.DataFrame) -> pd.DataFrame:
         return chunk
 
     # Parser le JSON radiationaurcs pour extraire la date
-    chunk["radiation_rcs_date"] = chunk["radiationaurcs"].apply(parse_radiation_json)
+    chunk["radiation_date"] = chunk["radiationaurcs"].apply(parse_radiation_json)
 
     # Marquer comme radié (présent dans le fichier = radié)
-    chunk["radiation_rcs"] = 1
+    chunk["radiation_est_radie"] = 1
 
     # Garder uniquement les colonnes nécessaires
-    chunk["radiation_rcs_date_publication"] = chunk["dateparution"]
-    chunk["radiation_rcs_id"] = chunk["id"]
+    chunk["radiation_date_publication"] = chunk["dateparution"]
+    chunk["radiation_id_annonce"] = chunk["id"]
     return chunk[
         [
             "siren",
-            "radiation_rcs_id",
-            "radiation_rcs",
-            "radiation_rcs_date",
-            "radiation_rcs_date_publication",
+            "radiation_id_annonce",
+            "radiation_est_radie",
+            "radiation_date",
+            "radiation_date_publication",
         ]
     ]
 
@@ -89,24 +89,24 @@ def process_procedure_chunk(chunk: pd.DataFrame) -> pd.DataFrame:
     chunk["procedure_collective_nature"] = chunk["jugement_parsed"].apply(
         lambda x: x.get("nature", "") if x else ""
     )
-    chunk["procedure_collective_complement_jugement"] = chunk["jugement_parsed"].apply(
+    chunk["procedure_collective_complement"] = chunk["jugement_parsed"].apply(
         lambda x: x.get("complementJugement", "") if x else ""
     )
-    chunk["procedure_collective_date_jugement"] = chunk["jugement_parsed"].apply(
+    chunk["procedure_collective_date"] = chunk["jugement_parsed"].apply(
         lambda x: x.get("date", "") if x else ""
     )
 
     # Garder uniquement les colonnes nécessaires
     chunk["procedure_collective_date_publication"] = chunk["dateparution"]
-    chunk["procedure_collective_id"] = chunk["id"]
+    chunk["procedure_collective_id_annonce"] = chunk["id"]
     return chunk[
         [
             "siren",
-            "procedure_collective_id",
+            "procedure_collective_id_annonce",
             "procedure_collective_famille",
             "procedure_collective_nature",
-            "procedure_collective_complement_jugement",
-            "procedure_collective_date_jugement",
+            "procedure_collective_complement",
+            "procedure_collective_date",
             "procedure_collective_date_publication",
         ]
     ]
@@ -189,10 +189,10 @@ class BodaccProcessor(DataProcessor):
             return pd.DataFrame(
                 columns=[
                     "siren",
-                    "radiation_rcs_id",
-                    "radiation_rcs",
-                    "radiation_rcs_date",
-                    "radiation_rcs_date_publication",
+                    "radiation_id_annonce",
+                    "radiation_est_radie",
+                    "radiation_date",
+                    "radiation_date_publication",
                 ]
             )
 
@@ -201,16 +201,16 @@ class BodaccProcessor(DataProcessor):
 
         # Environ 109 dates de radiations avec des dates absurdes comme 1213-10-03 ou 5019-06-01
         # Ces "erreurs" sont ignorées lors des conversions en datetime
-        df["radiation_rcs_date"] = pd.to_datetime(
-            df["radiation_rcs_date"], errors="coerce", format="%Y-%m-%d"
+        df["radiation_date"] = pd.to_datetime(
+            df["radiation_date"], errors="coerce", format="%Y-%m-%d"
         )
-        df["radiation_rcs_date_publication"] = pd.to_datetime(
-            df["radiation_rcs_date_publication"], errors="coerce", format="%Y-%m-%d"
+        df["radiation_date_publication"] = pd.to_datetime(
+            df["radiation_date_publication"], errors="coerce", format="%Y-%m-%d"
         )
 
         # Dédupliquer par Siren en gardant la radiation la plus récente
         df = df.sort_values(
-            ["radiation_rcs_date", "radiation_rcs_date_publication"],
+            ["radiation_date", "radiation_date_publication"],
             ascending=[False, False],
         )
         duplicated_mask = df.duplicated(subset=["siren"], keep="first")
@@ -225,10 +225,10 @@ class BodaccProcessor(DataProcessor):
         return df[
             [
                 "siren",
-                "radiation_rcs_id",
-                "radiation_rcs",
-                "radiation_rcs_date",
-                "radiation_rcs_date_publication",
+                "radiation_id_annonce",
+                "radiation_est_radie",
+                "radiation_date",
+                "radiation_date_publication",
             ]
         ]
 
@@ -263,11 +263,11 @@ class BodaccProcessor(DataProcessor):
             return pd.DataFrame(
                 columns=[
                     "siren",
-                    "procedure_collective_id",
+                    "procedure_collective_id_annonce",
                     "procedure_collective_statut",
                     "procedure_collective_nature",
-                    "procedure_collective_complement_jugement",
-                    "procedure_collective_date_jugement",
+                    "procedure_collective_complement",
+                    "procedure_collective_date",
                     "procedure_collective_date_publication",
                     "procedure_collective_cloturee_nature",
                 ]
@@ -281,7 +281,7 @@ class BodaccProcessor(DataProcessor):
         df["procedure_collective_statut"] = df.apply(
             lambda row: apply_procedure_collective_rules(
                 row["procedure_collective_nature"],
-                row["procedure_collective_complement_jugement"],
+                row["procedure_collective_complement"],
                 rules,
             ),
             axis=1,
@@ -289,8 +289,8 @@ class BodaccProcessor(DataProcessor):
 
         # Environ 5 dates de procédures collectives avec des dates absurdes comme 0009-12-02 ou 5025-05-27
         # Ces "erreurs" sont ignorées lors des conversions en datetime
-        df["procedure_collective_date_jugement"] = pd.to_datetime(
-            df["procedure_collective_date_jugement"], errors="coerce", format="%Y-%m-%d"
+        df["procedure_collective_date"] = pd.to_datetime(
+            df["procedure_collective_date"], errors="coerce", format="%Y-%m-%d"
         )
         df["procedure_collective_date_publication"] = pd.to_datetime(
             df["procedure_collective_date_publication"],
@@ -301,7 +301,7 @@ class BodaccProcessor(DataProcessor):
         # Dédupliquer par SIREN en gardant la procédure la plus récente
         df = df.sort_values(
             [
-                "procedure_collective_date_jugement",
+                "procedure_collective_date",
                 "procedure_collective_date_publication",
             ],
             ascending=[False, False],
@@ -319,7 +319,7 @@ class BodaccProcessor(DataProcessor):
         df["is_cloture"] = df["procedure_collective_famille"].apply(is_cloture)
 
         ten_years_ago = pd.Timestamp.now() - pd.DateOffset(years=10)
-        df["is_expired"] = df["procedure_collective_date_jugement"] < ten_years_ago
+        df["is_expired"] = df["procedure_collective_date"] < ten_years_ago
 
         # Créer les colonnes finales
         df["procedure_collective_cloturee_nature"] = df.apply(
@@ -358,11 +358,11 @@ class BodaccProcessor(DataProcessor):
         return df[
             [
                 "siren",
-                "procedure_collective_id",
+                "procedure_collective_id_annonce",
                 "procedure_collective_statut",
                 "procedure_collective_nature",
-                "procedure_collective_complement_jugement",
-                "procedure_collective_date_jugement",
+                "procedure_collective_complement",
+                "procedure_collective_date",
                 "procedure_collective_date_publication",
                 "procedure_collective_cloturee_nature",
             ]

--- a/workflows/data_pipelines/bodacc/rule.yml
+++ b/workflows/data_pipelines/bodacc/rule.yml
@@ -1,0 +1,196 @@
+procedure_collective_rules:
+  # The order of the rules matters
+  # The first rule to match an annonce will define its status
+  # Rules:
+  # 1. An exact match on `nature`
+  # 2. `complementJugement` should include the string in `complement_contains` [optional]
+
+  ##########################
+  # Liquidation judiciaire #
+  ###########################
+
+  - nature: "Jugement d'ouverture de liquidation judiciaire"
+    statut: "liquidation_judiciaire"
+
+  - nature: "Jugement d'extension de liquidation judiciaire"
+    statut: "liquidation_judiciaire"
+
+  - nature: "Jugement de conversion en liquidation judiciaire"
+    statut: "liquidation_judiciaire"
+
+  - nature: "Jugement de conversion en liquidation judiciaire de la procédure de sauvegarde"
+    statut: "liquidation_judiciaire"
+
+  - nature: "Jugement de conversion en liquidation judiciaire de la procédure de sauvegarde financière accélérée"
+    statut: "liquidation_judiciaire"
+
+  - nature: "Jugement prononçant la résolution du plan de sauvegarde et la liquidation judiciaire"
+    statut: "liquidation_judiciaire"
+
+  - nature: "Jugement prononçant la résolution du plan de sauvegarde accélérée et la liquidation judiciaire"
+    statut: "liquidation_judiciaire"
+
+  - nature: "Jugement prononçant la résolution du plan de sauvegarde financière accélérée et la liquidation judiciaire"
+    statut: "liquidation_judiciaire"
+
+  - nature: "Jugement prononçant la résolution du plan de cession et la liquidation judiciaire"
+    statut: "liquidation_judiciaire"
+
+  - nature: "Jugement prononçant la résolution du plan de traitement de sortie de crise et la liquidation judiciaire"
+    statut: "liquidation_judiciaire"
+
+  - nature: "Jugement mettant fin à la procédure de traitement de sortie de crise et ouvrant une procédure de liquidation judiciaire"
+    statut: "liquidation_judiciaire"
+
+  - nature: "Autre jugement prononçant"
+    complement_contains: "liquidation judiciaire"
+    statut: "liquidation_judiciaire"
+
+  - nature: "Autre jugement d'ouverture"
+    complement_contains: "liquidation judiciaire"
+    statut: "liquidation_judiciaire"
+
+  ###########################
+  # Redressement judiciaire #
+  ###########################
+
+  - nature: "Jugement d'ouverture d'une procédure de redressement judiciaire"
+    statut: "redressement_judiciaire"
+
+  - nature: "Jugement d'extension d'une procédure de redressement judiciaire"
+    statut: "redressement_judiciaire"
+
+  - nature: "Jugement prononçant la résolution du plan de sauvegarde et le redressement judiciaire"
+    statut: "redressement_judiciaire"
+
+  - nature: "Jugement de conversion en redressement judiciaire de la procédure de sauvegarde"
+    statut: "redressement_judiciaire"
+
+  - nature: "Jugement de conversion en redressement judiciaire de la procédure de sauvegarde financière accélérée"
+    statut: "redressement_judiciaire"
+
+  - nature: "Jugement mettant fin à la procédure de traitement de sortie de crise et ouvrant une procédure de redressement judiciaire"
+    statut: "redressement_judiciaire"
+
+  - nature: "Autre jugement prononçant"
+    complement_contains: "redressement judiciaire"
+    statut: "redressement_judiciaire"
+
+  - nature: "Autre jugement d'ouverture"
+    complement_contains: "redressement judiciaire"
+    statut: "redressement_judiciaire"
+
+  ##############
+  # Sauvegarde #
+  ##############
+
+  - nature: "Jugement d'ouverture d'une procédure de sauvegarde"
+    statut: "sauvegarde"
+
+  - nature: "Jugement d'extension d'une procédure de sauvegarde"
+    statut: "sauvegarde"
+
+  - nature: "Jugement d'ouverture d'une procédure de sauvegarde accélérée"
+    statut: "sauvegarde"
+
+  - nature: "Jugement d'ouverture d'une procédure de sauvegarde financière accélérée"
+    statut: "sauvegarde"
+
+  - nature: "Autre jugement prononçant"
+    complement_contains: "sauvegarde"
+    statut: "sauvegarde"
+
+  - nature: "Autre jugement d'ouverture"
+    complement_contains: "sauvegarde"
+    statut: "sauvegarde"
+
+  ############
+  # Clôtures #
+  ############
+
+  # "famille": "Extrait de jugement" - to implement - edge case
+  - nature: "Jugement de plan de redressement"
+    complement_contains: "continuation de l’activité"
+    statut: null
+
+  - nature: "Jugement de clôture pour insuffisance d'actif"
+    statut: null
+
+  - nature: "Jugement de clôture pour extinction du passif"
+    statut: null
+
+  - nature: "Jugement de clôture pour insuffisance d'actif et autorisant la reprise des poursuites individuelles"
+    statut: null
+
+  - nature: "Jugement de clôture de la liquidation des biens pour insuffisance d'actif"
+    statut: null
+
+  - nature: "Jugement de clôture de la liquidation des biens pour extinction du passif"
+    statut: null
+
+  - nature: "Jugement de clôture de la procédure de sauvegarde"
+    statut: null
+
+  - nature: "Jugement prononçant la clôture de la procédure de rétablissement professionnel"
+    # Ceci n'est pas une procédure collective. Annonces mal catégorisées ?
+    statut: null
+
+  - nature: "Jugement prononçant la résolution du plan de sauvegarde"
+    # Résolution du plan de sauvegarde mais sans indication de la procédure à suivre
+    statut: null
+
+  - nature: "Autre jugement de liquidation des biens"
+    statut: null
+
+  - nature: "Autre jugement de clôture"
+    statut: null
+
+  ##########
+  # OTHERS #
+  ##########
+
+  - nature: "Autre arrêt de la Cour d'Appel"
+    statut: null
+
+  - nature: "Arrêt de la cour d'appel infirmant une décision soumise à publicité"
+    statut: null
+
+  - nature: "Jugement d'ouverture d'une procédure de traitement de sortie de crise"
+    # Procédure obsolète
+    statut: null
+
+  - nature: "Jugement de désignation des organes de la procédure"
+    statut: null
+
+  - nature: "Jugement accordant un délai pour déposer la liste des créances"
+    statut: null
+
+  - nature: "Dépôt de l'état des créances"
+    statut: null
+
+  - nature: "Dépôt de l'état des créances Loi de 1985"
+    statut: null
+
+  - nature: "Dépôt de l'état de collocation"
+    statut: null
+
+  - nature: "Dépôt du projet de répartition"
+    statut: null
+
+  - nature: "Dépôt de l'état des créances et du projet de répartition"
+    statut: null
+
+  - nature: "Liste des créances nées après le jugement d'ouverture d'une procédure de liquidation judiciaire"
+    statut: null
+
+  - nature: "Liste des créances nées après le jugement d'ouverture d'une procédure de redressement judiciaire"
+    statut: null
+
+  - nature: "Autre avis de dépôt"
+    statut: null
+
+  - nature: "Autre jugement prononçant"
+    statut: null
+
+  - nature: "Autre jugement d'ouverture"
+    statut: null

--- a/workflows/data_pipelines/bodacc/utils.py
+++ b/workflows/data_pipelines/bodacc/utils.py
@@ -1,8 +1,10 @@
 import json
 import logging
 import re
+from pathlib import Path
 
 import pandas as pd
+import yaml
 
 from data_pipelines_annuaire.helpers.utils import parse_json_safe
 
@@ -285,3 +287,38 @@ def extract_siren_from_registre(df: pd.DataFrame) -> pd.DataFrame:
     # que les Siren avec un mauvais format
     df = df[df["siren"].notna() & (df["siren"] != "")]
     return df
+
+
+RULES_PATH = Path(__file__).parent / "rule.yml"
+
+
+def load_procedure_collective_rules() -> list[dict]:
+    with open(RULES_PATH, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return data["procedure_collective_rules"]
+
+
+def apply_procedure_collective_rules(
+    nature: str, complement_jugement: str, rules: list[dict]
+) -> str | None:
+    """
+    Applique les règles dans l'ordre. Retourne le statut de la première règle
+    qui matche, ou None si aucune règle ne correspond (avec un warning loggé).
+    """
+    if not nature:
+        return None
+
+    for rule in rules:
+        if rule["nature"] != nature:
+            continue
+        if "complement_contains" in rule:
+            if (
+                not complement_jugement
+                or rule["complement_contains"].lower()
+                not in complement_jugement.lower()
+            ):
+                continue
+        return rule.get("statut")
+
+    logging.warning(f"BODACC: nature non traitée dans rule.yml : '{nature}'")
+    return None

--- a/workflows/data_pipelines/bodacc/utils.py
+++ b/workflows/data_pipelines/bodacc/utils.py
@@ -89,18 +89,19 @@ def parse_radiation_json(radiation_str: str) -> str:
 
 
 def parse_jugement_json(jugement_str: str) -> dict:
-    """Parse le champs Json jugement et en extraire famille, nature et date."""
+    """Parse le champ json jugement et en extraire famille, nature, complementJugement et date."""
     if pd.isna(jugement_str) or not jugement_str:
-        return {"famille": "", "nature": "", "date": ""}
+        return {"famille": "", "nature": "", "complementJugement": "", "date": ""}
     try:
         data = json.loads(jugement_str)
         return {
-            "famille": data.get("famille", ""),
-            "nature": data.get("nature", ""),
+            "famille": fix_mojibake(data.get("famille", "")),
+            "nature": fix_mojibake(data.get("nature", "")),
+            "complementJugement": fix_mojibake(data.get("complementJugement", "")),
             "date": parse_date_bodacc(data.get("date", "")),
         }
     except json.JSONDecodeError:
-        return {"famille": "", "nature": "", "date": ""}
+        return {"famille": "", "nature": "", "complementJugement": "", "date": ""}
 
 
 def is_procedure_en_cours(nature: str) -> bool:

--- a/workflows/data_pipelines/bodacc/utils.py
+++ b/workflows/data_pipelines/bodacc/utils.py
@@ -7,6 +7,16 @@ import pandas as pd
 from data_pipelines_annuaire.helpers.utils import parse_json_safe
 
 
+def fix_mojibake(text: str) -> str:
+    """Répare les chaînes UTF-8 mal décodées en Latin-1 (ex: 'clÃ´ture' -> 'clôture')."""
+    if not text:
+        return text
+    try:
+        return text.encode("latin-1").decode("utf-8")
+    except (UnicodeDecodeError, UnicodeEncodeError):
+        return text
+
+
 def parse_date_bodacc(date_str: str) -> str:
     """
     Parse une date BODACC et retourne au format YYYY-MM-DD.
@@ -112,10 +122,8 @@ def is_procedure_en_cours(nature: str) -> bool:
 
 def is_cloture(famille: str) -> bool:
     """Vérifie si la famille correspond à une clôture de procédure."""
-    # Familles de jugement indiquant une clôture
     FAMILLES_CLOTURE = [
         "jugement de clôture",
-        "jugement de clÃ´ture",  # Encodage UTF-8 mal interprété
     ]
     if pd.isna(famille) or not famille:
         return False

--- a/workflows/data_pipelines/elasticsearch/mapping_index.py
+++ b/workflows/data_pipelines/elasticsearch/mapping_index.py
@@ -257,11 +257,21 @@ class ImmatriculationMapping(InnerDoc):
     devise_capital = Keyword()
 
 
+class BodaccRadiationMapping(InnerDoc):
+    est_radie = Boolean()
+    id_annonce = Keyword()
+    date = Date()
+
+
+class BodaccProcedureCollectiveMapping(InnerDoc):
+    statut = Keyword()
+    id_annonce = Keyword()
+    date = Date()
+
+
 class BodaccMapping(InnerDoc):
-    radiation_rcs = Boolean()
-    radiation_rcs_date = Date()
-    procedure_collective_nature = Keyword()
-    procedure_collective_date_jugement = Date()
+    radiation = Object(BodaccRadiationMapping)
+    procedure_collective = Object(BodaccProcedureCollectiveMapping)
 
 
 class UniteLegaleMapping(InnerDoc):

--- a/workflows/data_pipelines/elasticsearch/process_unites_legales.py
+++ b/workflows/data_pipelines/elasticsearch/process_unites_legales.py
@@ -286,10 +286,24 @@ def process_unites_legales(chunk_unites_legales_sqlite):
         bodacc = unite_legale.get("bodacc")
         if bodacc:
             bodacc_data = json.loads(bodacc)
-            bodacc_data["radiation_rcs"] = sqlite_str_to_bool(
-                bodacc_data.get("radiation_rcs", 0)
-            )
-            unite_legale_processed["bodacc"] = bodacc_data
+            est_radie = sqlite_str_to_bool(bodacc_data.get("radiation_est_radie", 0))
+            procedure_colletive_statut = bodacc_data.get("procedure_collective_statut")
+            unite_legale_processed["bodacc"] = {
+                "radiation": {
+                    "est_radie": est_radie,
+                    "id_annonce": bodacc_data.get("radiation_id_annonce"),
+                    "date": bodacc_data.get("radiation_date"),
+                }
+                if est_radie
+                else None,
+                "procedure_collective": {
+                    "statut": procedure_colletive_statut,
+                    "id_annonce": bodacc_data.get("procedure_collective_id_annonce"),
+                    "date": bodacc_data.get("procedure_collective_date"),
+                }
+                if procedure_colletive_statut
+                else None,
+            }
         else:
             unite_legale_processed["bodacc"] = {}
 

--- a/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
+++ b/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
@@ -408,10 +408,12 @@ select_fields_to_index_query = """SELECT
             ) as immatriculation,
             (
                 SELECT json_object(
-                    'radiation_rcs', radiation_rcs,
-                    'radiation_rcs_date', radiation_rcs_date,
-                    'procedure_collective_nature', procedure_collective_nature,
-                    'procedure_collective_date_jugement', procedure_collective_date_jugement
+                    'radiation_est_radie', radiation_est_radie,
+                    'radiation_id_annonce', radiation_id_annonce,
+                    'radiation_date', radiation_date,
+                    'procedure_collective_id_annonce', procedure_collective_id_annonce,
+                    'procedure_collective_statut', procedure_collective_statut,
+                    'procedure_collective_date', procedure_collective_date
                 )
                 FROM bodacc
                 WHERE siren = ul.siren


### PR DESCRIPTION
Closes #746 
Related to https://github.com/annuaire-entreprises-data-gouv-fr/search-api/pull/698

Live sur dev-01.
Peut être review par commit.

### Suppression des procédures collectives de plus de 10 ans

Il est suspect qu'une entreprise soit encore en procédure après tant de temps. Par sécurité nous préférons pour le moment ne pas les identifier tel quel.

### Harmonisation du texte

Beaucoup de lignes ont eu des problèmes d'encodage avant leur exposition sur le fichier BODACC. Exemple : 'clÃ´ture' -> 'clôture'
Ces caractères sont corrigés pour harmoniser l'ensemble des champs de textes du jugement afin de faciliter leur traitement à posteriori.

### Ajout du champs `complementJugement` dans la base de données et la logique

Le payload `jugement` des procédures collectives contient aussi un champs `complementJugement` en plus de `famille`, `nature` et `date`. Il s'agit cependant de texte libre. Mais dans certains cas, minoritaires heureusement, il est nécessaire de faire une recherche dans ce champs pour préciser la nature du jugement.

### Nouveau champs `statut` créé

Il remplace le champs précédent `nature` qui est un champs natif du BODACC.
Les valeurs possibles sont : `redressement_judiciaire`, `liquidation_judiciaire`, `sauvegarde` ou `null`. Il correspond au type de procédure collective en cours pour l'entreprise le cas échéant.
La logique est basée sur un fichier `rule.yaml` pour faciliter sa mise à jour et sa compréhension. Il est amené à évoluer en fonction des retours et de nos analyses.
<img width="739" height="147" alt="image" src="https://github.com/user-attachments/assets/9eda5a58-12a0-4dc4-8352-c0fb6854bb75" />

### Renomme les champs et modifie le format de l'objet BODACC dans l'index

Pour plus de cohérence entre tous les repos et matcher avec l'issue https://github.com/annuaire-entreprises-data-gouv-fr/site/issues/1638#issuecomment-4395352081