### PR TITLE
refactor: remove obsolete transform coordinates function

### DIFF
--- a/helpers/geolocalisation.py
+++ b/helpers/geolocalisation.py
@@ -4,8 +4,6 @@ import numpy as np
 import pandas as pd
 import pyproj
 
-from data_pipelines_annuaire.helpers.utils import is_valid_number
-
 EPSG_BY_TERRITORY: dict[str, int] = {
     # La France européenne - RGF93 / Lambert-93
     "default": 2154,
@@ -154,14 +152,3 @@ def convert_dataframe_lambert_to_gps(
     df["longitude"] = coords["longitude"]
 
     return df
-
-
-def transform_coordinates(department_code, x, y):
-    if not is_valid_number(x) or not is_valid_number(y):
-        return None, None
-
-    epsg = get_epsg_from_code(department_code, None) or 2154
-    lat, lon = convert_lambert_to_gps(float(x), float(y), epsg)
-
-    # Return as string to maintain backward compatibility with the datagouv DAG
-    return str(lat) if lat is not None else None, str(lon) if lon is not None else None

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -22,16 +22,6 @@ def check_if_prod():
     return AIRFLOW_ENV == "prod"
 
 
-def is_valid_number(value):
-    if value is None:
-        return False
-    try:
-        float(value)
-        return True
-    except ValueError:
-        return False
-
-
 def str_to_list(string):
     if string is None:
         return None

--- a/workflows/data_pipelines/elasticsearch/data_enrichment.py
+++ b/workflows/data_pipelines/elasticsearch/data_enrichment.py
@@ -3,9 +3,6 @@ import logging
 
 from slugify import slugify
 
-from data_pipelines_annuaire.helpers.geolocalisation import (
-    transform_coordinates,
-)
 from data_pipelines_annuaire.helpers.utils import (
     drop_exact_duplicates,
     get_empty_string_if_none,
@@ -550,15 +547,6 @@ def format_etablissements_and_complements(
         etablissement["region"] = label_region_from_departement(
             etablissement["departement"]
         )
-        if etablissement["latitude"] is None or etablissement["longitude"] is None:
-            (
-                etablissement["latitude"],
-                etablissement["longitude"],
-            ) = transform_coordinates(
-                etablissement["departement"],
-                etablissement["x"],
-                etablissement["y"],
-            )
         etablissement["ancien_siege"] = sqlite_str_to_bool(
             etablissement["ancien_siege"]
         )
@@ -613,12 +601,6 @@ def format_siege_unite_legale(siege, is_non_diffusible=False):
         is_non_diffusible,
     )
     siege["departement"] = format_departement(siege["commune"])
-    if siege["latitude"] is None or siege["longitude"] is None:
-        siege["latitude"], siege["longitude"] = transform_coordinates(
-            siege["departement"],
-            siege["x"],
-            siege["y"],
-        )
     siege["coordonnees"] = format_coordonnees(siege["longitude"], siege["latitude"])
     siege["region"] = label_region_from_departement(siege["departement"])
     siege["epci"] = label_epci_from_commune(siege["commune"])


### PR DESCRIPTION
No need to fallback on `transform_coordinates()` now.
If `latitude` and `longitude` are empty, it would mean `x` and `y` are as well, or are invalid.
All transformations are taking place upstream in the SIRENE pre-processing DAG.