### PR TITLE
feat(bodacc): add visibility rule to radiation

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,6 +29,7 @@ class DataSourceConfig:
         endpoint_api (str | None): Specific endpoint of the API to fetch data from. Defaults to None.
         auth_api (str | None): Authentication credentials for the API. Defaults to None.
         table_ddl (str | None): SQL query to create the database table in the ETL DAG. Defaults to None.
+        post_processing_queries (str | list[str] | None): queries to execute after the table has been created and loaded
     """
 
     name: str
@@ -44,6 +45,7 @@ class DataSourceConfig:
     endpoint_api: str | None = None
     auth_api: str | None = None
     table_ddl: str | None = None
+    post_processing_queries: str | list[str] | None = None
 
 
 CURRENT_MONTH: str = datetime.now().strftime("%Y-%m")

--- a/helpers/database_constructor.py
+++ b/helpers/database_constructor.py
@@ -57,7 +57,10 @@ class DatabaseTableConstructor:
             f"{self.config.name} table!"
         )
 
-    def etl_post_processing(self, db_location: str) -> None:
+        if self.config.post_processing_queries:
+            self._etl_post_processing(db_location)
+
+    def _etl_post_processing(self, db_location: str) -> None:
         """
         Execute queries after the table creation.
         Especially useful to apply updates requiring joins on other tables.
@@ -92,4 +95,3 @@ class DatabaseTableConstructor:
                     f"post-processing query {i + 1}: {current_total - previous_total} rows updated"
                 )
                 previous_total = current_total
-            sqlite_client.commit_and_close_conn()

--- a/helpers/database_constructor.py
+++ b/helpers/database_constructor.py
@@ -29,7 +29,7 @@ class DatabaseTableConstructor:
             - self.config.name (str): The name of the table to create.
 
         Args:
-            sqlite_client (SqliteClient): The SQLite client to use.
+            db_location (str): The SQLite database location to target.
         """
         if not self.config.table_ddl:
             raise ValueError("No table DDL provided in the configuration.")
@@ -56,3 +56,40 @@ class DatabaseTableConstructor:
             f"************ {row_count} total records have been added to the "
             f"{self.config.name} table!"
         )
+
+    def etl_post_processing(self, db_location: str) -> None:
+        """
+        Execute queries after the table creation.
+        Especially useful to apply updates requiring joins on other tables.
+
+        Configurations:
+            - self.config.post_processing_queries (list[str]):
+                The queries to execute in order.
+            - self.config.name (str): The name of the table to update.
+
+        Args:
+            db_location (str): The SQLite database location to target.
+        """
+        if not self.config.post_processing_queries:
+            raise ValueError(
+                "No post-processing queries provided in the configuration."
+            )
+        if not self.config.name:
+            raise ValueError("No table name provided in the configuration.")
+        queries = self.config.post_processing_queries
+        if isinstance(queries, str):
+            queries = [queries]
+
+        with SqliteClient(db_location) as sqlite_client:
+            logging.info(
+                f"Execution post-processing queries on {self.config.name} table.."
+            )
+            previous_total = 0
+            for i, query in enumerate(queries):
+                sqlite_client.execute(query)
+                current_total = sqlite_client.db_conn.total_changes
+                logging.info(
+                    f"post-processing query {i + 1}: {current_total - previous_total} rows updated"
+                )
+                previous_total = current_total
+            sqlite_client.commit_and_close_conn()

--- a/tests/e2e_tests/test_api.py
+++ b/tests/e2e_tests/test_api.py
@@ -920,14 +920,13 @@ def test_bodacc(api_response_tester):
     api_response_tester.test_field_value(path, 0, "bodacc.procedure_collective", None)
 
     # SIREN 442750196 : entreprise PP EI, radiée au RCS, SIRENE et RNE
+    # Cas particulier dont les radiations sont masquées par précaution pour le moment
     path = "/search?q=442750196&include_admin=bodacc"
     api_response_tester.assert_api_response_code_200(path)
 
-    api_response_tester.test_field_value(path, 0, "bodacc.radiation.est_radie", True)
-    api_response_tester.test_field_value(
-        path, 0, "bodacc.radiation.id_annonce", "B201401431107"
-    )
-    api_response_tester.test_field_value(path, 0, "bodacc.radiation.date", "2014-06-01")
+    api_response_tester.test_field_value(path, 0, "bodacc.radiation.est_radie", None)
+    api_response_tester.test_field_value(path, 0, "bodacc.radiation.id_annonce", None)
+    api_response_tester.test_field_value(path, 0, "bodacc.radiation.date", None)
     api_response_tester.test_field_value(path, 0, "bodacc.procedure_collective", None)
 
     # SIREN 776326126 : entreprise PP non EI, nature juridique 2110, radiée RCS mais active SIRENE et RNE

--- a/tests/e2e_tests/test_api.py
+++ b/tests/e2e_tests/test_api.py
@@ -920,7 +920,7 @@ def test_bodacc(api_response_tester):
     api_response_tester.test_field_value(path, 0, "bodacc.procedure_collective", None)
 
     # SIREN 442750196 : entreprise PP EI, radiée au RCS le 1er juin 2024
-    # Mais nouvelle établissement avec date de début d'activité au 2016-09-15
+    # Mais nouveau établissement avec date de début d'activité au 2016-09-15
     # Donc on considère la date de radiation comme obsolète et doit être masquée
     path = "/search?q=442750196&include_admin=bodacc"
     api_response_tester.assert_api_response_code_200(path)

--- a/tests/e2e_tests/test_api.py
+++ b/tests/e2e_tests/test_api.py
@@ -919,14 +919,20 @@ def test_bodacc(api_response_tester):
     api_response_tester.test_field_value(path, 0, "bodacc.radiation", None)
     api_response_tester.test_field_value(path, 0, "bodacc.procedure_collective", None)
 
-    # SIREN 442750196 : entreprise PP EI, radiée au RCS, SIRENE et RNE
-    # Cas particulier dont les radiations sont masquées par précaution pour le moment
+    # SIREN 442750196 : entreprise PP EI, radiée au RCS le 1er juin 2024
+    # Mais nouvelle établissement avec date de début d'activité au 2016-09-15
+    # Donc on considère la date de radiation comme obsolète et doit être masquée
     path = "/search?q=442750196&include_admin=bodacc"
     api_response_tester.assert_api_response_code_200(path)
 
-    api_response_tester.test_field_value(path, 0, "bodacc.radiation.est_radie", None)
-    api_response_tester.test_field_value(path, 0, "bodacc.radiation.id_annonce", None)
-    api_response_tester.test_field_value(path, 0, "bodacc.radiation.date", None)
+    api_response_tester.test_field_value(path, 0, "bodacc.radiation", None)
+    api_response_tester.test_field_value(path, 0, "bodacc.procedure_collective", None)
+
+    # SIREN 448900399 : cas particulier dont les radiations sont masquées par précaution pour le moment
+    path = "/search?q=448900399&include_admin=bodacc"
+    api_response_tester.assert_api_response_code_200(path)
+
+    api_response_tester.test_field_value(path, 0, "bodacc.radiation", None)
     api_response_tester.test_field_value(path, 0, "bodacc.procedure_collective", None)
 
     # SIREN 776326126 : entreprise PP non EI, nature juridique 2110, radiée RCS mais active SIRENE et RNE

--- a/workflows/data_pipelines/bodacc/config.py
+++ b/workflows/data_pipelines/bodacc/config.py
@@ -38,8 +38,47 @@ BODACC_CONFIG = DataSourceConfig(
             procedure_collective_date DATE,
             procedure_collective_date_publication DATE,
 
-            procedure_collective_cloturee_nature TEXT
+            procedure_collective_cloturee_nature TEXT,
+
+            radiation_visibility INTEGER DEFAULT 1,
+            radiation_visibility_reason TEXT DEFAULT 'visible_by_default'
         );
         COMMIT;
     """,
+    post_processing_queries=[
+        """
+            UPDATE bodacc
+            SET radiation_visibility = 0,
+                radiation_visibility_reason = 'ei_active_on_sirene'
+            WHERE bodacc.radiation_est_radie
+            AND siren IN (
+                SELECT ul.siren
+                FROM unite_legale AS ul
+                INNER JOIN etablissement AS e ON e.siren = ul.siren
+                WHERE bodacc.siren = ul.siren
+                AND ul.nature_juridique_unite_legale = '1000'
+                AND ul.etat_administratif_unite_legale = 'A'
+                AND e.etat_administratif_etablissement = 'A'
+            )
+            """,
+        """
+            UPDATE bodacc
+            SET radiation_visibility = 0,
+                radiation_visibility_reason = 'ei_with_new_etab_since_radiation'
+            WHERE bodacc.radiation_est_radie
+            AND siren IN (
+                SELECT ul.siren
+                FROM unite_legale AS ul
+                INNER JOIN etablissement AS e ON e.siren = ul.siren
+                left join immatriculation AS i on i.siren = ul.siren
+                WHERE bodacc.siren = ul.siren
+                AND ul.nature_juridique_unite_legale = '1000'
+                AND (
+                    e.date_creation >= bodacc.radiation_date
+                 OR e.date_debut_activite >= bodacc.radiation_date
+                 OR i.date_immatriculation >= bodacc.radiation_date
+                 )
+            )
+            """,
+    ],
 )

--- a/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
+++ b/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
@@ -408,9 +408,9 @@ select_fields_to_index_query = """SELECT
             ) as immatriculation,
             (
                 SELECT json_object(
-                    'radiation_est_radie', radiation_est_radie,
-                    'radiation_id_annonce', radiation_id_annonce,
-                    'radiation_date', radiation_date,
+                    'radiation_est_radie', case when radiation_visibility then radiation_est_radie end,
+                    'radiation_id_annonce', case when radiation_visibility then radiation_id_annonce end,
+                    'radiation_date', case when radiation_visibility then radiation_date end,
                     'procedure_collective_id_annonce', procedure_collective_id_annonce,
                     'procedure_collective_statut', procedure_collective_statut,
                     'procedure_collective_date', procedure_collective_date


### PR DESCRIPTION
PR pour ne pas indexer la date de radiation lorsque nous ne sommes pas sur que la date de radiation s'applique à l'EI.
Le filtre est construit dans le DAG ETL car il nécessite de croiser les infos avec la base SIRENE.
Mais son application est au niveau de l'indexation elasticsearch afin de faciliter son suivi et son amélioration.

État des lieux des siren ayant une date de radiation au RCS suite aux modifications de cette PR :

<img width="1148" height="179" alt="image" src="https://github.com/user-attachments/assets/36262722-2071-4ec5-95c9-52b0c7905f0f" />

Running on dev-01.