### PR TITLE
feat(datagouv): manage also the json docs and descriptions

### DIFF
--- a/helpers/datagouv.py
+++ b/helpers/datagouv.py
@@ -132,6 +132,20 @@ def post_resource(
     return r
 
 
+def update_dataset_metadata(dataset_id: str, payload: dict):
+    url = f"{DATAGOUV_URL}/api/1/datasets/{dataset_id}/"
+    r = datagouv_session.put(url, json=payload)
+    r.raise_for_status()
+    return r.json()
+
+
+def update_dataset_description(dataset_id: str, dest_path: str, dest_name: str):
+    with open(os.path.join(dest_path, dest_name), "r", encoding="utf-8") as f:
+        description = f.read()
+    update_dataset_metadata(dataset_id, {"description": description})
+    logging.info(f"Updated description for dataset {dataset_id}")
+
+
 def fetch_last_modified_date(resource_id: str) -> str:
     """
     Fetch the 'last_modified' date of a resource from data.gouv.fr.

--- a/workflows/data_pipelines/data_gouv/dag.py
+++ b/workflows/data_pipelines/data_gouv/dag.py
@@ -8,6 +8,10 @@ from data_pipelines_annuaire.config import (
     EMAIL_LIST,
 )
 from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers.datagouv import (
+    post_resource,
+    update_dataset_description,
+)
 from data_pipelines_annuaire.helpers.utils import check_if_prod
 from data_pipelines_annuaire.workflows.data_pipelines.data_gouv.processor import (
     DataGouvProcessor,
@@ -79,6 +83,44 @@ def publish_files_in_data_gouv():
     def send_files_to_data_gouv():
         return data_gouv_processor.publish_to_datagouv()
 
+    @task
+    def update_annuaire_description():
+        return update_dataset_description(
+            DataGouvProcessor.DATASET_ID_ANNUAIRE,
+            DataGouvProcessor.DESCRIPTIONS_DIR,
+            "description_annuaire.md",
+        )
+
+    @task
+    def update_administration_description():
+        return update_dataset_description(
+            DataGouvProcessor.DATASET_ID_ADMINISTRATION,
+            DataGouvProcessor.DESCRIPTIONS_DIR,
+            "description_administration.md",
+        )
+
+    @task
+    def update_doc_unite_legale():
+        return post_resource(
+            file_to_upload={
+                "dest_path": DataGouvProcessor.DESCRIPTIONS_DIR,
+                "dest_name": "documentation_unite_legale.json",
+            },
+            dataset_id=DataGouvProcessor.DATASET_ID_ANNUAIRE,
+            resource_id=DataGouvProcessor.RESOURCE_ID_DOC_UL,
+        )
+
+    @task
+    def update_doc_etablissement():
+        return post_resource(
+            file_to_upload={
+                "dest_path": DataGouvProcessor.DESCRIPTIONS_DIR,
+                "dest_name": "documentation_etablissement.json",
+            },
+            dataset_id=DataGouvProcessor.DATASET_ID_ANNUAIRE,
+            resource_id=DataGouvProcessor.RESOURCE_ID_DOC_ETAB,
+        )
+
     @task.bash(trigger_rule="all_done")
     def clean_outputs():
         return f"rm -rf {AIRFLOW_DAG_TMP}publish_data_gouv"
@@ -95,6 +137,12 @@ def publish_files_in_data_gouv():
         >> upload_etablissement_file_to_object_storage()
         >> check_if_prod_env()
         >> send_files_to_data_gouv()
+        >> [
+            update_annuaire_description(),
+            update_administration_description(),
+            update_doc_unite_legale(),
+            update_doc_etablissement(),
+        ]
         >> clean_outputs()
     )
 

--- a/workflows/data_pipelines/data_gouv/description_administration.md
+++ b/workflows/data_pipelines/data_gouv/description_administration.md
@@ -1,10 +1,15 @@
-Ce jeu de données contient une liste **des administrations françaises qui peuvent accéder à l'[espace agent de l'Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr/lp/agent-public)**. Elle est tenue par la Direction Interministérielle du Numérique (DINUM). Elle est mise à jour quotidiennement.
+Ce jeu de données contient une liste **des administrations françaises qui peuvent accéder à l'[espace agent de l'Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr/lp/agent-public).**  Elle est tenue par la Direction Interministérielle du Numérique (DINUM). Elle est mise à jour quotidiennement.
 
-Elle regroupe deux types d'administrations :
+Elle regroupe quatre types d'administrations :
 
 * les organismes chargés d'une mission de service public administratif
 
+* les administrations de l'État (services centraux, déconcentrés et critères de régie ou quasi-régie)
+
+* les collectivités
+
 * les administrations autorisées à accéder à l'espace agent de l'Annuaire des Entreprises
+
 
 
 Pour chaque administration, la liste contient :
@@ -15,10 +20,10 @@ Pour chaque administration, la liste contient :
 
 * la dénomination
 
-* est-elle chargée d'une mission de service public administratif ou autorisée à accéder à l'espace agent
+* est-elle une administration de l'État, une collectivité, chargée d'une mission de service public administratif  ou autorisée à accéder à l'espace agent ?
 
 Ce jeu de donnée est le fruit d'un travail en cours, mené par la DINUM. Il est possible qu'une organisation n’apparaisse pas dans la liste, alors qu'elle le devrait.
 
 Si une organisation n’apparait pas dans la liste, vous pouvez [demander à la Direction interministérielle du numérique (DINUM) d’étudier son ajout à la liste](https://demarche.numerique.gouv.fr/commencer/demande-d-ajout-a-la-liste-des-administrations).
 
-Si la demande est acceptée par la DINUM, le SIREN de **votre administration sera ajoutée à la liste et le badge "Administration" sera affiché sur l’[Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr/)**.
+Si la demande est acceptée par la DINUM, le SIREN de **votre administration sera ajoutée à la liste et le badge "Administration" sera affiché sur** **[l’Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr "Nouvel onglet")**.

--- a/workflows/data_pipelines/data_gouv/description_administration.md
+++ b/workflows/data_pipelines/data_gouv/description_administration.md
@@ -1,0 +1,24 @@
+Ce jeu de données contient une liste **des administrations françaises qui peuvent accéder à l'[espace agent de l'Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr/lp/agent-public)**. Elle est tenue par la Direction Interministérielle du Numérique (DINUM). Elle est mise à jour quotidiennement.
+
+Elle regroupe deux types d'administrations :
+
+* les organismes chargés d'une mission de service public administratif
+
+* les administrations autorisées à accéder à l'espace agent de l'Annuaire des Entreprises
+
+
+Pour chaque administration, la liste contient :
+
+* le numéro SIREN
+
+* le code juridique
+
+* la dénomination
+
+* est-elle chargée d'une mission de service public administratif ou autorisée à accéder à l'espace agent
+
+Ce jeu de donnée est le fruit d'un travail en cours, mené par la DINUM. Il est possible qu'une organisation n’apparaisse pas dans la liste, alors qu'elle le devrait.
+
+Si une organisation n’apparait pas dans la liste, vous pouvez [demander à la Direction interministérielle du numérique (DINUM) d’étudier son ajout à la liste](https://demarche.numerique.gouv.fr/commencer/demande-d-ajout-a-la-liste-des-administrations).
+
+Si la demande est acceptée par la DINUM, le SIREN de **votre administration sera ajoutée à la liste et le badge "Administration" sera affiché sur l’[Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr/)**.

--- a/workflows/data_pipelines/data_gouv/description_annuaire.md
+++ b/workflows/data_pipelines/data_gouv/description_annuaire.md
@@ -1,8 +1,8 @@
 Ces jeux de données contiennent certaines informations sur les entreprises françaises disponibles dans [l'Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr/) et dans son [API de Recherche](https://api.gouv.fr/les-api/api-recherche-entreprises).
 
-Les données proviennent de plusieurs [sources de données](https://annuaire-entreprises.data.gouv.fr/donnees/sources), soit à la maille de l’unité légale (siren) soit à la maille de l’établissement (siret).
+Les données proviennent de plusieurs [sources de données](https://annuaire-entreprises.data.gouv.fr/donnees/sources), soit à la maille de l'unité légale (siren) soit à la maille de l'établissement (siret).
 
-L’équipe data.gouv.fr publie ces jeux de données afin de simplifier la jointure entre les différents jeux de données publics utilisant le SIREN ou le SIRET.
+L'équipe data.gouv.fr publie ces jeux de données afin de simplifier la jointure entre les différents jeux de données publics utilisant le SIREN ou le SIRET.
 
 **Attention**, il ne s'agit pas ici d'une fusion de tous ces jeux de données.
 
@@ -20,15 +20,25 @@ L’équipe data.gouv.fr publie ces jeux de données afin de simplifier la joint
 
     * Statut de diffusion (OUI/NON)
 
-    * Nombre d’établissements
+    * Nombre d'établissements
+
+    * Nombre d'établissements ouverts
+
+    * Nature juridique
 
     * Entreprise individuelle (OUI/NON)
 
     * Association (OUI/NON et numéro RNA)
 
+    * Société à mission
+
+    * ESS
+
   * Champ calculé à partir des données de la base Sirene :
 
     * Nom complet affiché sur Annuaire des Entreprises
+
+    * Administration (OUI/NON)
 
   * Autre sources :
 
@@ -36,15 +46,25 @@ L’équipe data.gouv.fr publie ces jeux de données afin de simplifier la joint
 
     * Déclaration Egapro
 
-    * Récépissé de licence d’entrepreneur de spectacle
+    * Achats responsables
 
-    * ESS
+    * Alim'Confiance
+
+    * Récépissé de licence d'entrepreneur de spectacle
+
+    * Entreprise du Patrimoine Vivant
 
     * Organisme de formation
 
     * Qualiopi
 
     * Entreprise Inclusive / SIAE
+
+    * FINESS juridique
+
+    * Aide ADEME
+
+    * Avocat
 
     * Pour les collectivités territoriales
 
@@ -60,37 +80,29 @@ L’équipe data.gouv.fr publie ces jeux de données afin de simplifier la joint
 
     * SIRET
 
-    * SIREN de l’unité légale
+    * SIREN de l'unité légale
 
     * Siège social (OUI/NON)
+
+    * Ancien siège (OUI/NON)
 
     * État administratif (ACTIF/FERMÉ)
 
     * Statut de diffusion (OUI/NON)
 
-  * Champs calculés à partir de la Base Adresse Nationale et des champs d’adresse de la base Sirene :
-
-    * Adresse
-
-    * Coordonnées GPS (latitude, longitude)
+    * Adresse : champ calculé à partir des champs d'adresse de la base Sirene :
 
   * Autre sources :
 
-    * FINESS
+    * FINESS Géographique
 
     * BIO
 
     * Convention collective
 
-    * Reconnue Garant de l’Environnement
+    * Reconnue Garant de l'Environnement
 
     * UAI
-
-**Géolocalisation**
-
-Les coordonnées GPS ne sont pas calculés de la même manière que les coordonnées Lambert publiées par l’Insee dans la [base Sirene](https://www.data.gouv.fr/fr/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/).
-
-La plupart des numéros Siret utilisent le géocodage (latitude/longitude) provenant de la base SIRENE [géocodée par data.gouv](https://www.data.gouv.fr/fr/datasets/base-sirene-des-etablissements-siret-geolocalisee-avec-la-base-dadresse-nationale-ban/). Cependant, pour ceux modifiés après le début du mois en cours, la géolocalisation est directement extraite de la base SIRENE, en convertissant les coordonnées Lambert en coordonnées GPS.
 
 **Fréquence de publication**
 

--- a/workflows/data_pipelines/data_gouv/description_annuaire.md
+++ b/workflows/data_pipelines/data_gouv/description_annuaire.md
@@ -1,0 +1,97 @@
+Ces jeux de données contiennent certaines informations sur les entreprises françaises disponibles dans [l'Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr/) et dans son [API de Recherche](https://api.gouv.fr/les-api/api-recherche-entreprises).
+
+Les données proviennent de plusieurs [sources de données](https://annuaire-entreprises.data.gouv.fr/donnees/sources), soit à la maille de l’unité légale (siren) soit à la maille de l’établissement (siret).
+
+L’équipe data.gouv.fr publie ces jeux de données afin de simplifier la jointure entre les différents jeux de données publics utilisant le SIREN ou le SIRET.
+
+**Attention**, il ne s'agit pas ici d'une fusion de tous ces jeux de données.
+
+* Unité légale :
+
+  * Base Sirene :
+
+    * SIREN
+
+    * SIRET du siège
+
+    * Date de mise a jour des données dans la base sirene
+
+    * État administratif (ACTIVE/CESSÉE)
+
+    * Statut de diffusion (OUI/NON)
+
+    * Nombre d’établissements
+
+    * Entreprise individuelle (OUI/NON)
+
+    * Association (OUI/NON et numéro RNA)
+
+  * Champ calculé à partir des données de la base Sirene :
+
+    * Nom complet affiché sur Annuaire des Entreprises
+
+  * Autre sources :
+
+    * Date de mise à jour des données dans le Registre National des Entreprises
+
+    * Déclaration Egapro
+
+    * Récépissé de licence d’entrepreneur de spectacle
+
+    * ESS
+
+    * Organisme de formation
+
+    * Qualiopi
+
+    * Entreprise Inclusive / SIAE
+
+    * Pour les collectivités territoriales
+
+      * Code commune
+
+      * Elus
+
+    * Liste de toutes les Conventions Collectives
+
+* Etablissement :
+
+  * Base Sirene :
+
+    * SIRET
+
+    * SIREN de l’unité légale
+
+    * Siège social (OUI/NON)
+
+    * État administratif (ACTIF/FERMÉ)
+
+    * Statut de diffusion (OUI/NON)
+
+  * Champs calculés à partir de la Base Adresse Nationale et des champs d’adresse de la base Sirene :
+
+    * Adresse
+
+    * Coordonnées GPS (latitude, longitude)
+
+  * Autre sources :
+
+    * FINESS
+
+    * BIO
+
+    * Convention collective
+
+    * Reconnue Garant de l’Environnement
+
+    * UAI
+
+**Géolocalisation**
+
+Les coordonnées GPS ne sont pas calculés de la même manière que les coordonnées Lambert publiées par l’Insee dans la [base Sirene](https://www.data.gouv.fr/fr/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/).
+
+La plupart des numéros Siret utilisent le géocodage (latitude/longitude) provenant de la base SIRENE [géocodée par data.gouv](https://www.data.gouv.fr/fr/datasets/base-sirene-des-etablissements-siret-geolocalisee-avec-la-base-dadresse-nationale-ban/). Cependant, pour ceux modifiés après le début du mois en cours, la géolocalisation est directement extraite de la base SIRENE, en convertissant les coordonnées Lambert en coordonnées GPS.
+
+**Fréquence de publication**
+
+Ces données sont mises à jour quotidiennement. Ce jeu de données représente un extrait partiel des informations utilisées par l'Annuaire. D'autres évolutions sont prévues pour ces fichiers, avec l'intégration de nouveaux champs.

--- a/workflows/data_pipelines/data_gouv/documentation_etablissement.json
+++ b/workflows/data_pipelines/data_gouv/documentation_etablissement.json
@@ -21,6 +21,11 @@
       "description": "L'établissement a précédemment servi de siège de l'unité légale (source : base Sirene)"
     },
     {
+      "name": "adresse",
+      "type": "string",
+      "description": "Champ construit depuis les champs d'adresse de la base SIRENE"
+    },
+    {
       "name": "etat_administratif",
       "type": "string",
       "description": "Etat administratif de l'établissement. 'A' pour Actif, 'F' pour Fermé (source : base Sirene)"
@@ -34,24 +39,9 @@
       }
     },
     {
-      "name": "adresse",
-      "type": "string",
-      "description": "Champs construit depuis les champs d'adresse de la base SIRENE : complement adresse + numéro voie + indice repetition + type voie + libelle voie + distribution spéciale + (code postal + libelle commune | cedex + libelle cedex) + libelle commune étranger + libelle pays étranger"
-    },
-    {
-      "name": "latitude",
-      "type": "string",
-      "description": "Latitude de l'établissement (source : base Sirene géocodée par data.gouv)"
-    },
-    {
-      "name": "longitude",
-      "type": "string",
-      "description": "Longitude de l'établissement (source : base Sirene géocodée par data.gouv)"
-    },
-    {
-      "name": "liste_finess",
+      "name": "liste_finess_geographique",
       "type": "array",
-      "description": "Liste des identifiants FINESS de l'établissement (source : Ministère des Solidarités et de la Santé)",
+      "description": "Liste des identifiants FINESS Géographiques de l'établissement (source : Ministère des Solidarités et de la Santé)",
       "items": {
         "type": "string"
       }

--- a/workflows/data_pipelines/data_gouv/documentation_etablissement.json
+++ b/workflows/data_pipelines/data_gouv/documentation_etablissement.json
@@ -1,0 +1,92 @@
+{
+  "fields": [
+    {
+      "name": "siren",
+      "type": "string",
+      "description": "SIREN de l'unité légale (source : base Sirene)"
+    },
+    {
+      "name": "siret",
+      "type": "string",
+      "description": "Numéro unique de l'établissement (source : base Sirene)"
+    },
+    {
+      "name": "est_siege",
+      "type": "boolean",
+      "description": "L'établissement est le siège de l'unité légale (source : base Sirene)"
+    },
+    {
+      "name": "ancien_siege",
+      "type": "boolean",
+      "description": "L'établissement a précédemment servi de siège de l'unité légale (source : base Sirene)"
+    },
+    {
+      "name": "etat_administratif",
+      "type": "string",
+      "description": "Etat administratif de l'établissement. 'A' pour Actif, 'F' pour Fermé (source : base Sirene)"
+    },
+    {
+      "name": "statut_diffusion",
+      "type": "string",
+      "description": "Statut de diffusion de l'établissement (source : base Sirene)",
+      "constraints": {
+        "enum": ["O", "P"]
+      }
+    },
+    {
+      "name": "adresse",
+      "type": "string",
+      "description": "Champs construit depuis les champs d'adresse de la base SIRENE : complement adresse + numéro voie + indice repetition + type voie + libelle voie + distribution spéciale + (code postal + libelle commune | cedex + libelle cedex) + libelle commune étranger + libelle pays étranger"
+    },
+    {
+      "name": "latitude",
+      "type": "string",
+      "description": "Latitude de l'établissement (source : base Sirene géocodée par data.gouv)"
+    },
+    {
+      "name": "longitude",
+      "type": "string",
+      "description": "Longitude de l'établissement (source : base Sirene géocodée par data.gouv)"
+    },
+    {
+      "name": "liste_finess",
+      "type": "array",
+      "description": "Liste des identifiants FINESS de l'établissement (source : Ministère des Solidarités et de la Santé)",
+      "items": {
+        "type": "string"
+      }
+    },
+    {
+      "name": "liste_id_bio",
+      "type": "array",
+      "description": "Liste des identifiants BIO de l'établissement (source : Agence Bio)",
+      "items": {
+        "type": "string"
+      }
+    },
+    {
+      "name": "liste_idcc",
+      "type": "array",
+      "description": "Liste des conventions collectives de l'établissement (source : Ministère du travail)",
+      "items": {
+        "type": "string"
+      }
+    },
+    {
+      "name": "liste_rge",
+      "type": "array",
+      "description": "Liste des identifiants RGE de l'établissement (source : ADEME)",
+      "items": {
+        "type": "string"
+      }
+    },
+    {
+      "name": "liste_uai",
+      "type": "array",
+      "description": "Liste des identifiants UAI de l'établissement (source : Ministère de l'enseignement supérieur et de la recherche)",
+      "items": {
+        "type": "string"
+      }
+    }
+  ]
+}

--- a/workflows/data_pipelines/data_gouv/documentation_unite_legale.json
+++ b/workflows/data_pipelines/data_gouv/documentation_unite_legale.json
@@ -11,11 +11,6 @@
       "description": "Numéro unique de l'établissement siège (source: base Sirene)"
     },
     {
-      "name": "nom_complet",
-      "type": "string",
-      "description": "Champs construit depuis les champs de dénomination : denomination de l'unité légale | Nom et prénom | Nom inconnu (dénomination usuelle : construite à partir des trois champs de dénomination usuelle de la base SIRENE) (sigle de l'unité légale)"
-    },
-    {
       "name": "etat_administratif",
       "type": "string",
       "description": "État administratif de l'unité légale. 'A' pour Active, 'C' pour Cessée (source : base Sirene)"
@@ -37,6 +32,16 @@
       "name": "nombre_etablissements_ouverts",
       "type": "integer",
       "description": "Nombre des établissements ouverts de l'unité légale (source : base Sirene)"
+    },
+    {
+      "name": "nom_complet",
+      "type": "string",
+      "description": "Champs construit depuis les champs de dénomination : denomination de l'unité légale | Nom et prénom | Nom inconnu (dénomination usuelle : construite à partir des trois champs de dénomination usuelle de la base SIRENE) (sigle de l'unité légale)"
+    },
+    {
+      "name": "nature_juridique",
+      "type": "string",
+      "description": "Nature juridique de l'unité légale (source : base Sirene)"
     },
     {
       "name": "colter_code",
@@ -77,6 +82,16 @@
       "description": "Indique si au moins un établissement a un indice égalité professionnel H/F renseigné (source : Ministère du Travail du Plein emploi et de l'Insertion)"
     },
     {
+      "name": "est_achats_responsables",
+      "type": "boolean",
+      "description": "Entreprise engagée dans une démarche d'achats responsables (source : Marché de l'Inclusion)"
+    },
+    {
+      "name": "est_alim_confiance",
+      "type": "boolean",
+      "description": "Établissement référencé dans Alim'confiance (source : Ministère de l'Agriculture et de la Souveraineté alimentaire)"
+    },
+    {
       "name": "est_association",
       "type": "boolean",
       "description": "L'unité légale est une association (source : base Sirene)"
@@ -90,6 +105,11 @@
       "name": "est_entrepreneur_spectacle",
       "type": "boolean",
       "description": "Entreprise ayant une licence d'entrepreneur du spectacle (source : Ministère de la Culture)"
+    },
+    {
+      "name": "est_patrimoine_vivant",
+      "type": "boolean",
+      "description": "Entreprise détentrice du label Entreprise du Patrimoine Vivant (source : Ministère de l'Économie)"
     },
     {
       "name": "statut_entrepreneur_spectacle",
@@ -118,7 +138,7 @@
     },
     {
       "name": "est_societe_mission",
-      "type": "boolean",
+      "type": "string",
       "description": "Société qui appartient au champ des sociétés à mission (source : base Sirene)"
     },
     {
@@ -145,6 +165,24 @@
       "name": "type_siae",
       "type": "string",
       "description": "Type de structure de l'inclusion (source : Marché de l'Inclusion)"
+    },
+    {
+      "name": "liste_finess_juridique",
+      "type": "array",
+      "description": "Liste des identifiants FINESS juridiques de l'unité légale (source : Ministère des Solidarités et de la Santé)",
+      "items": {
+        "type": "string"
+      }
+    },
+    {
+      "name": "a_aide_ademe",
+      "type": "boolean",
+      "description": "Entreprise ayant reçu une aide de l'ADEME (source : ADEME)"
+    },
+    {
+      "name": "est_avocat",
+      "type": "boolean",
+      "description": "Unité légale enregistrée en tant qu'avocat (source : Conseil National des Barreaux)"
     }
   ]
 }

--- a/workflows/data_pipelines/data_gouv/documentation_unite_legale.json
+++ b/workflows/data_pipelines/data_gouv/documentation_unite_legale.json
@@ -1,0 +1,150 @@
+{
+  "fields": [
+    {
+      "name": "siren",
+      "type": "string",
+      "description": "Numéro unique de l'entreprise (source: base Sirene)"
+    },
+    {
+      "name": "siret_siege",
+      "type": "string",
+      "description": "Numéro unique de l'établissement siège (source: base Sirene)"
+    },
+    {
+      "name": "nom_complet",
+      "type": "string",
+      "description": "Champs construit depuis les champs de dénomination : denomination de l'unité légale | Nom et prénom | Nom inconnu (dénomination usuelle : construite à partir des trois champs de dénomination usuelle de la base SIRENE) (sigle de l'unité légale)"
+    },
+    {
+      "name": "etat_administratif",
+      "type": "string",
+      "description": "État administratif de l'unité légale. 'A' pour Active, 'C' pour Cessée (source : base Sirene)"
+    },
+    {
+      "name": "statut_diffusion",
+      "type": "string",
+      "description": "Statut de diffusion de le l'unité légale (source : base Sirene)",
+      "constraints": {
+        "enum": ["O", "P"]
+      }
+    },
+    {
+      "name": "nombre_etablissements",
+      "type": "integer",
+      "description": "Nombre des établissements de l'unité légale (source : base Sirene)"
+    },
+    {
+      "name": "nombre_etablissements_ouverts",
+      "type": "integer",
+      "description": "Nombre des établissements ouverts de l'unité légale (source : base Sirene)"
+    },
+    {
+      "name": "colter_code",
+      "type": "string",
+      "description": "Code affilié à une collectivité territoriale (Commune - code INSEE, EPCI - n° SIREN, Département - Code INSEE + 'D' (sauf cas particulier), Région - Code INSEE)"
+    },
+    {
+      "name": "colter_code_insee",
+      "type": "string",
+      "description": "Code INSEE de la collectivité territoriale"
+    },
+    {
+      "name": "colter_elus",
+      "type": "string",
+      "description": "Élus enregistrés au Répertoire National des Élus(source : Ministère de l'Intérieur et des Outre-Mer)"
+    },
+    {
+      "name": "colter_niveau",
+      "type": "string",
+      "description": "Niveau de collectivité territoriale",
+      "constraints": {
+        "enum": ["commune", "epci", "departement", "region", "particulier"]
+      }
+    },
+    {
+      "name": "date_mise_a_jour_insee",
+      "type": "date",
+      "description": "Date de mise à jour de la donnée dans la base Sirene (source: base Sirene)"
+    },
+    {
+      "name": "date_mise_a_jour_rne",
+      "type": "date",
+      "description": "Date de mise à jour de la donnée dans le RNE (source : le RNE)"
+    },
+    {
+      "name": "egapro_renseignee",
+      "type": "boolean",
+      "description": "Indique si au moins un établissement a un indice égalité professionnel H/F renseigné (source : Ministère du Travail du Plein emploi et de l'Insertion)"
+    },
+    {
+      "name": "est_association",
+      "type": "boolean",
+      "description": "L'unité légale est une association (source : base Sirene)"
+    },
+    {
+      "name": "est_entrepreneur_individuel",
+      "type": "boolean",
+      "description": "Entreprise individuelle (source : base Sirene)"
+    },
+    {
+      "name": "est_entrepreneur_spectacle",
+      "type": "boolean",
+      "description": "Entreprise ayant une licence d'entrepreneur du spectacle (source : Ministère de la Culture)"
+    },
+    {
+      "name": "statut_entrepreneur_spectacle",
+      "type": "string",
+      "description": "Statut des établissements ayant fait une demande de licence d'entrepreneur du spectacle (source : Ministère de la Culture)"
+    },
+    {
+      "name": "est_ess",
+      "type": "boolean",
+      "description": "Entreprises appartenant au champ de l'économie sociale et solidaire (source : base Sirene et ESS France)"
+    },
+    {
+      "name": "est_organisme_formation",
+      "type": "boolean",
+      "description": "Entreprise ayant au moins un établissement organisme de formation (source : Ministère du Travail)"
+    },
+    {
+      "name": "est_qualiopi",
+      "type": "boolean",
+      "description": "Entreprise ayant une certification de la marque « Qualiopi » (source : Ministère du Travail)"
+    },
+    {
+      "name": "est_administration",
+      "type": "boolean",
+      "description": "Uniquement les structures reconnues comme administration. Attention : Cette donnée se base sur des règles de gestion documentées ici: https://github.com/annuaire-entreprises-data-gouv-fr/search-infra/blob/97b81953f060015b881f44482897a066f2cd34cf/data_enrichment.py#L103. Cette donnée n'est pas exhaustive et peut contenir des faux positifs."
+    },
+    {
+      "name": "est_societe_mission",
+      "type": "boolean",
+      "description": "Société qui appartient au champ des sociétés à mission (source : base Sirene)"
+    },
+    {
+      "name": "liste_elus",
+      "type": "string",
+      "description": "Liste des élus s'il s'agit de collectivé territoriale (source : Ministère de l'Intérieur et des Outre-Mer)"
+    },
+    {
+      "name": "liste_id_organisme_formation",
+      "type": "string",
+      "description": "Liste des numéros de déclaration d'activité des établissement organismes de formation (source : Ministère du Travail)"
+    },
+    {
+      "name": "liste_idcc",
+      "type": "string",
+      "description": "Liste des conventions collectives de l'unité légale (source : Ministère du travail)"
+    },
+    {
+      "name": "est_siae",
+      "type": "boolean",
+      "description": "Structure d'insertion par l'activité économique (source : Marché de l'Inclusion)"
+    },
+    {
+      "name": "type_siae",
+      "type": "string",
+      "description": "Type de structure de l'inclusion (source : Marché de l'Inclusion)"
+    }
+  ]
+}

--- a/workflows/data_pipelines/data_gouv/processor.py
+++ b/workflows/data_pipelines/data_gouv/processor.py
@@ -45,6 +45,12 @@ from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.data_enrichm
 
 
 class DataGouvProcessor:
+    DESCRIPTIONS_DIR = os.path.dirname(__file__)
+    DATASET_ID_ANNUAIRE = "667ebdd4547ab9bd6e4682d3"
+    DATASET_ID_ADMINISTRATION = "67a5cd40941cbe4c206efcd1"
+    RESOURCE_ID_DOC_UL = "481a06cf-fcf9-417a-b4dd-687273727af9"
+    RESOURCE_ID_DOC_ETAB = "e8a88fe5-d1f5-4700-9cdf-af2c96eb7ef6"
+
     def __init__(self):
         self.today_date = datetime.today().strftime("%Y-%m-%d")
         self.chunk_size = 100000
@@ -519,27 +525,27 @@ class DataGouvProcessor:
         files_to_publish = [
             {
                 "file": f"unites_legales_{self.today_date}.csv.gz",
-                "dataset_id": "667ebdd4547ab9bd6e4682d3",
+                "dataset_id": self.DATASET_ID_ANNUAIRE,
                 "resource_id": "b8e5376c-c158-4d88-91f3-f6bb0d165332",
             },
             {
                 "file": f"unites_legales_{self.today_date}.parquet",
-                "dataset_id": "667ebdd4547ab9bd6e4682d3",
+                "dataset_id": self.DATASET_ID_ANNUAIRE,
                 "resource_id": "77f09ee6-8ccb-4eb8-ad10-382be6416065",
             },
             {
                 "file": f"etablissements_{self.today_date}.csv.gz",
-                "dataset_id": "667ebdd4547ab9bd6e4682d3",
+                "dataset_id": self.DATASET_ID_ANNUAIRE,
                 "resource_id": "12812d7d-d11c-45f4-965c-35a3b149c585",
             },
             {
                 "file": f"etablissements_{self.today_date}.parquet",
-                "dataset_id": "667ebdd4547ab9bd6e4682d3",
+                "dataset_id": self.DATASET_ID_ANNUAIRE,
                 "resource_id": "58427078-8afb-4651-9469-c9043991d892",
             },
             {
                 "file": f"liste_administrations_{self.today_date}.csv",
-                "dataset_id": "67a5cd40941cbe4c206efcd1",
+                "dataset_id": self.DATASET_ID_ADMINISTRATION,
                 "resource_id": "c0f355f1-66bd-4f57-8a3c-2c6f3527b364",
             },
         ]


### PR DESCRIPTION
On ne publie que les ressources sur datagouv en oubliant de mettre à jour la description et les fichiers documentaires.
Afin de résoudre ce problème, le DAG peut aussi s'occuper de les mettre à jours.
Ainsi ils seront à la fois à jour et à la fois mis à jour au même moment que le fichier.