### PR TITLE
feat(datagouv): add administration json documentation

### DIFF
--- a/workflows/data_pipelines/data_gouv/dag.py
+++ b/workflows/data_pipelines/data_gouv/dag.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 from airflow.providers.smtp.notifications.smtp import SmtpNotifier
-from airflow.sdk import dag, task
+from airflow.sdk import dag, setup, task, teardown
 
 from data_pipelines_annuaire.config import (
     AIRFLOW_DAG_TMP,
@@ -39,6 +39,7 @@ default_args = {
 def publish_files_in_data_gouv():
     data_gouv_processor = DataGouvProcessor()
 
+    @setup
     @task.bash
     def clean_previous_outputs():
         return f"rm -rf {AIRFLOW_DAG_TMP}publish_data_gouv && mkdir -p {AIRFLOW_DAG_TMP}publish_data_gouv"
@@ -132,7 +133,8 @@ def publish_files_in_data_gouv():
             resource_id=DataGouvProcessor.RESOURCE_ID_DOC_ETAB,
         )
 
-    @task.bash(trigger_rule="all_done")
+    @teardown
+    @task.bash
     def clean_outputs():
         return f"rm -rf {AIRFLOW_DAG_TMP}publish_data_gouv"
 

--- a/workflows/data_pipelines/data_gouv/dag.py
+++ b/workflows/data_pipelines/data_gouv/dag.py
@@ -84,19 +84,30 @@ def publish_files_in_data_gouv():
         return data_gouv_processor.publish_to_datagouv()
 
     @task
-    def update_annuaire_description():
-        return update_dataset_description(
-            DataGouvProcessor.DATASET_ID_ANNUAIRE,
-            DataGouvProcessor.DESCRIPTIONS_DIR,
-            "description_annuaire.md",
-        )
-
-    @task
     def update_administration_description():
         return update_dataset_description(
             DataGouvProcessor.DATASET_ID_ADMINISTRATION,
             DataGouvProcessor.DESCRIPTIONS_DIR,
             "description_administration.md",
+        )
+
+    @task
+    def update_doc_administration():
+        post_resource(
+            file_to_upload={
+                "dest_path": DataGouvProcessor.DESCRIPTIONS_DIR,
+                "dest_name": "documentation_administration.json",
+            },
+            dataset_id=DataGouvProcessor.DATASET_ID_ADMINISTRATION,
+            resource_id=DataGouvProcessor.RESOURCE_ID_DOC_ADMINISTRATION,
+        )
+
+    @task
+    def update_annuaire_description():
+        return update_dataset_description(
+            DataGouvProcessor.DATASET_ID_ANNUAIRE,
+            DataGouvProcessor.DESCRIPTIONS_DIR,
+            "description_annuaire.md",
         )
 
     @task
@@ -139,9 +150,10 @@ def publish_files_in_data_gouv():
         >> send_files_to_data_gouv()
         >> [
             update_annuaire_description(),
-            update_administration_description(),
             update_doc_unite_legale(),
             update_doc_etablissement(),
+            update_administration_description(),
+            update_doc_administration(),
         ]
         >> clean_outputs()
     )

--- a/workflows/data_pipelines/data_gouv/documentation_administration.json
+++ b/workflows/data_pipelines/data_gouv/documentation_administration.json
@@ -1,0 +1,39 @@
+{
+  "fields": [
+    {
+      "name": "siren",
+      "type": "string",
+      "description": "Numéro unique de l'entreprise (source: base Sirene)"
+    },
+    {
+      "name": "nom_complet",
+      "type": "string",
+      "description": "Champs construit depuis les champs de dénomination : denomination de l'unité légale | Nom et prénom | Nom inconnu (dénomination usuelle : construite à partir des trois champs de dénomination usuelle de la base SIRENE) (sigle de l'unité légale)"
+    },
+    {
+      "name": "nature_juridique",
+      "type": "string",
+      "description": "Catégorie juridique de l'unité légale (source: base Sirene)"
+    },
+    {
+      "name": "a_mission_service_public_administratif",
+      "type": "boolean",
+      "description": "Est-elle chargée d'une mission de service public administratif ?"
+    },
+    {
+      "name": "est_administration_d_etat",
+      "type": "boolean",
+      "description": "Est-elle une administration de l'État (services centraux, déconcentrés et critères de régie ou quasi-régie) ?"
+    },
+    {
+      "name": "est_collectivite",
+      "type": "boolean",
+      "description": "Est-elle une collectivité territoriale ?"
+    },
+    {
+      "name": "a_acces_espace_agent",
+      "type": "boolean",
+      "description": "Est-elle autorisée à accéder à l'espace agent de l'Annuaire des Entreprises ?"
+    }
+  ]
+}

--- a/workflows/data_pipelines/data_gouv/processor.py
+++ b/workflows/data_pipelines/data_gouv/processor.py
@@ -46,8 +46,9 @@ from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.data_enrichm
 
 class DataGouvProcessor:
     DESCRIPTIONS_DIR = os.path.dirname(__file__)
-    DATASET_ID_ANNUAIRE = "667ebdd4547ab9bd6e4682d3"
     DATASET_ID_ADMINISTRATION = "67a5cd40941cbe4c206efcd1"
+    RESOURCE_ID_DOC_ADMINISTRATION = "b905d718-cc7b-479e-a821-d8faf70ae1d4"
+    DATASET_ID_ANNUAIRE = "667ebdd4547ab9bd6e4682d3"
     RESOURCE_ID_DOC_UL = "481a06cf-fcf9-417a-b4dd-687273727af9"
     RESOURCE_ID_DOC_ETAB = "e8a88fe5-d1f5-4700-9cdf-af2c96eb7ef6"
 


### PR DESCRIPTION
* Fix the notification never failing because of the last cleaning task by using [teardown](https://airflow.apache.org/docs/apache-airflow/stable/howto/setup-and-teardown.html)
* Add the administration json documentation from [here](https://www.data.gouv.fr/datasets/liste-des-administrations-ayant-acces-a-lespace-agent-de-lannuaire-des-entreprises?resource_id=b905d718-cc7b-479e-a821-d8faf70ae1d4)