### PR TITLE
chore(cc): run metadata dag twice a month only

### DIFF
--- a/workflows/data_pipelines/metadata/cc/dag.py
+++ b/workflows/data_pipelines/metadata/cc/dag.py
@@ -22,7 +22,7 @@ default_args = {
 @dag(
     default_args=default_args,
     start_date=datetime(2026, 1, 1),
-    schedule="0 11 2-31/3 * *",  # At 11:00 on every 3rd day-of-month from 2nd through 31st
+    schedule="0 11 2,3 * *",  # At 11:00 on the 2nd and 3rd day of every month
     catchup=False,
     max_active_runs=1,
     dagrun_timeout=timedelta(minutes=(60 * 100)),


### PR DESCRIPTION
Very noisy dag that fails for months on end.
File has not been updated since 02/2026 https://travail-emploi.gouv.fr/conventions-collectives-nomenclatures