### PR TITLE
fix: dag version keep increasing

### DIFF
--- a/workflows/data_pipelines/elasticsearch/dag_index_data.py
+++ b/workflows/data_pipelines/elasticsearch/dag_index_data.py
@@ -90,6 +90,7 @@ def index_elasticsearch():
         trigger_snapshot_dag = TriggerDagRunOperator(
             task_id="trigger_snapshot_dag",
             trigger_dag_id=AIRFLOW_SNAPSHOT_DAG_NAME,
+            logical_date=None,
             wait_for_completion=True,
             deferrable=False,
         )
@@ -112,6 +113,7 @@ def index_elasticsearch():
     trigger_radiations_export_dag = TriggerDagRunOperator(
         task_id="trigger_radiations_export_dag",
         trigger_dag_id=AIRFLOW_EXPORT_DAG_NAME,
+        logical_date=None,
         wait_for_completion=False,
     )
 

--- a/workflows/data_pipelines/etl/dag.py
+++ b/workflows/data_pipelines/etl/dag.py
@@ -243,6 +243,7 @@ def database_constructor():
     trigger_indexing_dag = TriggerDagRunOperator(
         task_id="trigger_indexing_dag",
         trigger_dag_id=AIRFLOW_ELK_DAG_NAME,
+        logical_date=None,
         wait_for_completion=False,
         deferrable=False,
     )

--- a/workflows/data_pipelines/sirene/flux/dag.py
+++ b/workflows/data_pipelines/sirene/flux/dag.py
@@ -65,6 +65,7 @@ def data_processing_sirene_flux():
     trigger_etl_dag = TriggerDagRunOperator(
         task_id="trigger_indexing_dag",
         trigger_dag_id=AIRFLOW_ETL_DAG_NAME,
+        logical_date=None,
         wait_for_completion=False,
         deferrable=False,
     )


### PR DESCRIPTION
DAG versions keep increasing.
It concerns only the DAGs using `TriggerDagRunOperator`.
After some research it may come from how [this task](https://airflow.apache.org/docs/apache-airflow-providers-standard/stable/_modules/airflow/providers/standard/operators/trigger_dagrun.html#TriggerDagRunOperator) is serialized by Airflow.
And looking at the documentation it seems `logical_date` is set to now whenever it is left empty by default : 
<img width="726" height="179" alt="image" src="https://github.com/user-attachments/assets/345377d1-c97b-4f29-9798-6b36a2fcacb7" />
So the fix would be to set a value for `logical_date` so it does not default to `NOTSET` anymore.

I am not completely sure of the fix. It is currently being tested on dev-01 ✅ 

Fix validated:
<img width="131" height="167" alt="image" src="https://github.com/user-attachments/assets/7d66169b-0c19-407d-8405-688b22080aec" />
