### PR TITLE
perf: speed up sqlite database compression and upload tasks

### DIFF
--- a/airflow.Dockerfile
+++ b/airflow.Dockerfile
@@ -13,7 +13,7 @@ USER root
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    git lftp zip wget p7zip-full gcc g++
+    git lftp zip wget p7zip-full pigz gcc g++
 
 USER airflow
 

--- a/helpers/object_storage.py
+++ b/helpers/object_storage.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 from datetime import datetime
 from pathlib import Path
 from typing import TypedDict
@@ -102,6 +103,74 @@ class ObjectStorageClient:
                 raise Exception(
                     f"file {file['source_path']}{file['source_name']} does not exist"
                 )
+
+    def upload_compressed_file(
+        self,
+        source_file_path: str,
+        object_storage_path: str,
+        dest_name: str,
+        is_public: bool = True,
+        content_type: str | None = None,
+        compress_level: int = 6,
+    ) -> None:
+        """
+        Compress a local file with pigz (multi-threaded gzip) and stream the gzip
+        output straight to Object Storage without writing the .gz to local disk.
+
+        Args:
+            source_file_path (str): local file to compress and upload.
+            object_storage_path (str): destination path within the bucket.
+            dest_name (str): destination object name (should end with .gz).
+            is_public (bool): whether the object should be public. Defaults to True.
+            content_type (str | None): content type of the object. Defaults to None.
+            compress_level (int): pigz level (1-9). Defaults to 6.
+        """
+        if not os.path.isfile(source_file_path):
+            raise Exception(f"File {source_file_path} does not exist")
+
+        if not dest_name.endswith(".gz"):
+            raise Exception(f"Destination filename {dest_name} does not end with .gz")
+
+        object_key = f"{OBJECT_STORAGE_ENV_PATH}{object_storage_path}{dest_name}"
+
+        extra_args = {"ContentEncoding": "gzip"}
+        if is_public:
+            extra_args["ACL"] = "public-read"
+        if content_type:
+            extra_args["ContentType"] = content_type
+
+        logging.info(
+            f"Compressing and sending {dest_name} to {object_key} with pigz level {compress_level}"
+        )
+        proc = subprocess.Popen(
+            ["pigz", "-c", f"-{compress_level}", source_file_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,  # note: change to DEVNULL if it causes deadlocks
+        )
+        try:
+            self.client.upload_fileobj(
+                proc.stdout, self.bucket, object_key, ExtraArgs=extra_args
+            )
+        except Exception:
+            # Kill the subprocess in case of exception
+            proc.kill()
+            raise
+        finally:
+            # Close pipes
+            if proc.stdout:
+                proc.stdout.close()
+            # Read stderr before closing it, otherwise the error message is lost
+            stderr_output = proc.stderr.read() if proc.stderr else b""
+            if proc.stderr:
+                proc.stderr.close()
+            proc.wait()
+
+        if proc.returncode != 0:
+            error_output = stderr_output.decode(errors="replace")
+            raise RuntimeError(
+                f"pigz failed (exit {proc.returncode}) for "
+                f"{source_file_path}: {error_output}"
+            )
 
     def get_files_from_prefix(self, prefix: str):
         """Retrieve only the list of files in a S3 pattern

--- a/helpers/object_storage.py
+++ b/helpers/object_storage.py
@@ -152,8 +152,10 @@ class ObjectStorageClient:
                 proc.stdout, self.bucket, object_key, ExtraArgs=extra_args
             )
         except Exception:
-            # Kill the subprocess in case of exception
+            # Kill the subprocess in case of exception..
             proc.kill()
+            # ..and delete any residual file that may exist on object storage
+            self._delete_object_if_possible(object_key)
             raise
         finally:
             # Close pipes
@@ -166,11 +168,22 @@ class ObjectStorageClient:
             proc.wait()
 
         if proc.returncode != 0:
+            # When pigz fails while running boto3 will still have uploaded a valid but corrupted
+            # object. So the file has to be deleted so it can't be downloaded
+            self._delete_object_if_possible(object_key)
             error_output = stderr_output.decode(errors="replace")
             raise RuntimeError(
                 f"pigz failed (exit {proc.returncode}) for "
                 f"{source_file_path}: {error_output}"
             )
+
+    def _delete_object_if_possible(self, object_key: str) -> None:
+        """Delete an object while ignoring and logging errors. E.g. if the object does not exist."""
+        try:
+            self.client.delete_object(Bucket=self.bucket, Key=object_key)
+            logging.info(f"Delete object: {object_key}")
+        except ClientError as e:
+            logging.warning(f"Controlled failure to delete object: {object_key}\n{e}")
 
     def get_files_from_prefix(self, prefix: str):
         """Retrieve only the list of files in a S3 pattern

--- a/tests/unit_tests/test_object_storage.py
+++ b/tests/unit_tests/test_object_storage.py
@@ -1,10 +1,16 @@
 import gzip
-from unittest.mock import MagicMock
+import io
+import shutil
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from data_pipelines_annuaire.config import AIRFLOW_ENV
 from data_pipelines_annuaire.helpers.object_storage import ObjectStorageClient
+
+pigz_required = pytest.mark.skipif(
+    shutil.which("pigz") is None, reason="pigz binary is not installed"
+)
 
 
 def _make_client(keys):
@@ -92,3 +98,103 @@ def test_get_latest_database_raises_when_missing(tmp_path):
 
     with pytest.raises(Exception, match="No database file was found"):
         client.get_latest_database("sirene/database/", str(tmp_path / "sirene.db"))
+
+
+def _make_upload_client():
+    """Build a client whose upload_fileobj decompresses what it receives.
+
+    The uploaded gzip stream is gunzipped and stashed so the test can assert
+    the bytes round-trip exactly as a standard gzip member.
+    """
+    client = ObjectStorageClient.__new__(ObjectStorageClient)
+    client.bucket = "test-bucket"
+
+    captured = {}
+
+    def fake_upload_fileobj(fileobj, bucket, key, ExtraArgs=None):
+        captured["bucket"] = bucket
+        captured["key"] = key
+        captured["extra_args"] = ExtraArgs
+        captured["content"] = gzip.decompress(fileobj.read())
+
+    boto_client = MagicMock()
+    boto_client.upload_fileobj.side_effect = fake_upload_fileobj
+    client.client = boto_client
+    return client, captured
+
+
+@pigz_required
+def test_upload_compressed_file_roundtrips_as_gzip(tmp_path):
+    source = tmp_path / "sirene.db"
+    payload = b"SQLite format 3\x00" + b"some database bytes" * 1000
+    source.write_bytes(payload)
+
+    client, captured = _make_upload_client()
+
+    client.upload_compressed_file(
+        source_file_path=str(source),
+        object_storage_path="sirene/database/",
+        dest_name="sirene_2024-03-15.db.gz",
+    )
+
+    assert captured["content"] == payload
+    assert (
+        captured["key"] == f"ae/{AIRFLOW_ENV}/sirene/database/sirene_2024-03-15.db.gz"
+    )
+    assert captured["extra_args"]["ACL"] == "public-read"
+    assert captured["extra_args"]["ContentEncoding"] == "gzip"
+
+
+def test_upload_compressed_file_raises_when_dest_name_not_gz(tmp_path):
+    source = tmp_path / "sirene.db"
+    source.write_bytes(b"SQLite format 3\x00")
+
+    client, _ = _make_upload_client()
+
+    with pytest.raises(Exception, match="does not end with .gz"):
+        client.upload_compressed_file(
+            source_file_path=str(source),
+            object_storage_path="sirene/database/",
+            dest_name="sirene_2024-03-15.db",
+        )
+
+
+def test_upload_compressed_file_raises_when_pigz_fails(tmp_path):
+    source = tmp_path / "sirene.db"
+    source.write_bytes(b"SQLite format 3\x00")
+
+    client = ObjectStorageClient.__new__(ObjectStorageClient)
+    client.bucket = "test-bucket"
+    boto_client = MagicMock()
+    # Drain the stream without decompressing so the failure path is reached
+    boto_client.upload_fileobj.side_effect = (
+        lambda fileobj, bucket, key, ExtraArgs=None: fileobj.read()
+    )
+    client.client = boto_client
+
+    fake_proc = MagicMock()
+    fake_proc.stdout = io.BytesIO(b"")
+    fake_proc.stderr = io.BytesIO(b"pigz: abort: out of memory")
+    fake_proc.returncode = 1
+
+    with patch(
+        "data_pipelines_annuaire.helpers.object_storage.subprocess.Popen",
+        return_value=fake_proc,
+    ):
+        with pytest.raises(RuntimeError, match="pigz failed"):
+            client.upload_compressed_file(
+                source_file_path=str(source),
+                object_storage_path="sirene/database/",
+                dest_name="sirene_2024-03-15.db.gz",
+            )
+
+
+def test_upload_compressed_file_raises_when_source_missing(tmp_path):
+    client, _ = _make_upload_client()
+
+    with pytest.raises(Exception, match="does not exist"):
+        client.upload_compressed_file(
+            source_file_path=str(tmp_path / "missing.db"),
+            object_storage_path="sirene/database/",
+            dest_name="sirene_2024-03-15.db.gz",
+        )

--- a/tests/unit_tests/test_object_storage.py
+++ b/tests/unit_tests/test_object_storage.py
@@ -188,6 +188,45 @@ def test_upload_compressed_file_raises_when_pigz_fails(tmp_path):
                 dest_name="sirene_2024-03-15.db.gz",
             )
 
+    # The possibly-partial object must be deleted so it cannot be picked up later
+    boto_client.delete_object.assert_called_once_with(
+        Bucket="test-bucket",
+        Key=f"ae/{AIRFLOW_ENV}/sirene/database/sirene_2024-03-15.db.gz",
+    )
+
+
+def test_upload_compressed_file_deletes_object_when_upload_fails(tmp_path):
+    source = tmp_path / "sirene.db"
+    source.write_bytes(b"SQLite format 3\x00")
+
+    client = ObjectStorageClient.__new__(ObjectStorageClient)
+    client.bucket = "test-bucket"
+    boto_client = MagicMock()
+    boto_client.upload_fileobj.side_effect = RuntimeError("connection dropped")
+    client.client = boto_client
+
+    fake_proc = MagicMock()
+    fake_proc.stdout = io.BytesIO(b"")
+    fake_proc.stderr = io.BytesIO(b"")
+    fake_proc.returncode = 0
+
+    with patch(
+        "data_pipelines_annuaire.helpers.object_storage.subprocess.Popen",
+        return_value=fake_proc,
+    ):
+        with pytest.raises(RuntimeError, match="connection dropped"):
+            client.upload_compressed_file(
+                source_file_path=str(source),
+                object_storage_path="sirene/database/",
+                dest_name="sirene_2024-03-15.db.gz",
+            )
+
+    fake_proc.kill.assert_called_once()
+    boto_client.delete_object.assert_called_once_with(
+        Bucket="test-bucket",
+        Key=f"ae/{AIRFLOW_ENV}/sirene/database/sirene_2024-03-15.db.gz",
+    )
+
 
 def test_upload_compressed_file_raises_when_source_missing(tmp_path):
     client, _ = _make_upload_client()

--- a/workflows/data_pipelines/etl/dag.py
+++ b/workflows/data_pipelines/etl/dag.py
@@ -296,7 +296,7 @@ def database_constructor():
         # Labels and others
         >> additional_data_enrichement()
         # The End
-        >> upload_db_to_object_storage()
+        >> upload_db_to_object_storage(SIRENE_DATABASE_LOCATION)
         >> create_data_source_last_modified_file()
         >> clean_current_tmp_folder()
         >> trigger_indexing_dag

--- a/workflows/data_pipelines/etl/task_functions/upload_db.py
+++ b/workflows/data_pipelines/etl/task_functions/upload_db.py
@@ -1,49 +1,19 @@
-import gzip
-import logging
-import os
-import shutil
 from datetime import datetime
 
 from airflow.sdk import task
 
 from data_pipelines_annuaire.config import (
-    AIRFLOW_ETL_DATA_DIR,
     SIRENE_OBJECT_STORAGE_DATA_PATH,
 )
 from data_pipelines_annuaire.helpers.object_storage import ObjectStorageClient
 
-current_date = datetime.now().date()
-
-
-def send_to_object_storage(list_files):
-    ObjectStorageClient().send_files(
-        list_files=list_files,
-    )
-
 
 @task
-def upload_db_to_object_storage():
-    # Zip database
-    database_file_path = os.path.join(AIRFLOW_ETL_DATA_DIR, "sirene.db")
-
-    with open(database_file_path, "rb") as f_in:
-        with gzip.open(f"{database_file_path}.gz", "wb") as f_out:
-            shutil.copyfileobj(f_in, f_out)
-
-    send_to_object_storage(
-        [
-            {
-                "source_path": AIRFLOW_ETL_DATA_DIR,
-                "source_name": "sirene.db.gz",
-                "dest_path": SIRENE_OBJECT_STORAGE_DATA_PATH,
-                "dest_name": f"sirene_{current_date}.db.gz",
-            }
-        ]
+def upload_db_to_object_storage(database_file_path: str) -> None:
+    current_date = datetime.now().date()
+    ObjectStorageClient().upload_compressed_file(
+        source_file_path=database_file_path,
+        object_storage_path=SIRENE_OBJECT_STORAGE_DATA_PATH,
+        dest_name=f"sirene_{current_date}.db.gz",
+        content_type="application/vnd.sqlite3",
     )
-    # Delete the local database file after uploading to object storage
-    if os.path.exists(database_file_path):
-        os.remove(database_file_path)
-        os.remove(f"{database_file_path}.gz")
-        logging.info(f"Database deleted! {database_file_path}")
-    else:
-        logging.warning(f"Warning: Database file '{database_file_path}' not found.")

--- a/workflows/data_pipelines/rne/database/task_functions.py
+++ b/workflows/data_pipelines/rne/database/task_functions.py
@@ -342,31 +342,14 @@ def upload_db_to_object_storage():
     )
 
     database_file_path = os.path.join(RNE_DB_TMP_FOLDER, f"rne_{start_date}.db")
-    database_zip_file_path = os.path.join(RNE_DB_TMP_FOLDER, f"rne_{start_date}.db.gz")
-
-    # Zip database
-    with open(database_file_path, "rb") as f_in:
-        with gzip.open(database_zip_file_path, "wb") as f_out:
-            shutil.copyfileobj(f_in, f_out)
 
     logging.info(f"Sending database: rne_{start_date}.db.gz")
-    send_to_object_storage(
-        [
-            {
-                "source_path": RNE_DB_TMP_FOLDER,
-                "source_name": f"rne_{start_date}.db.gz",
-                "dest_path": RNE_OBJECT_STORAGE_DATA_PATH,
-                "dest_name": f"rne_{last_date_processed}.db.gz",
-            }
-        ]
+    ObjectStorageClient().upload_compressed_file(
+        source_file_path=database_file_path,
+        object_storage_path=RNE_OBJECT_STORAGE_DATA_PATH,
+        dest_name=f"rne_{last_date_processed}.db.gz",
+        content_type="application/vnd.sqlite3",
     )
-
-    # Delete local files after uploading to the object storage
-    os.remove(database_file_path)
-    if os.path.exists(database_zip_file_path):
-        os.remove(database_zip_file_path)
-    else:
-        logging.warning(f"Warning: Database file '{database_zip_file_path}' not found.")
 
 
 @task


### PR DESCRIPTION
**Cela fait gagner 1h sur les DAG `etl` et `fill_rne_database` !**

`gzip` est single-threaded alors que `pigz` est multi-threaded. À priori zstd est encore meilleure mais elle n'est pas compatible `.gz` et donc non rétro-compatible.
Test en local avec 8 coeurs montre une vitesse de compression x5 pour `pigz` en level 6 par rapport `gzip` au même niveau.

Cette PR n'utilise `pigz`  que pour la compression des bases sqlite. Les autres tasks n'étant pas des bottlenecks. À voir si on généralise son usage, mais il demande un peu plus de complexité au niveau code car aucune librairie Python de confiance n'existe du coup il faut utiliser un subprocess.

[Avant](https://airflow-dataeng-dev-01.bastion.annuaire-entreprises.infra.api.gouv.fr/dags/extract_transform_load_db/runs/manual__2026-06-16T07:48:16.328284+00:00_lr3APn73/tasks/upload_db_to_object_storage) : 
<img width="1030" height="423" alt="image" src="https://github.com/user-attachments/assets/145f392a-dbdd-444e-a3c0-085eaa4686d5" />

[Maintenant](https://airflow-dataeng-dev-01.bastion.annuaire-entreprises.infra.api.gouv.fr/dags/extract_transform_load_db/runs/manual__2026-06-21T08:13:04.499488+00:00_BOWNLk9o/tasks/upload_db_to_object_storage) : 
<img width="1017" height="401" alt="image" src="https://github.com/user-attachments/assets/8550dd3d-fcbd-4bf2-bd10-5a7fbd9005d1" />

Au passage au lieu de compresser puis d'upload le fichier, on stream le fichier compressé directement vers l'object storage.

Live on dev-01 ✅ 
Note : d'autres tentatives d'améliorations des performances sont live sur dev-01 du coup les temps d'exécution totaux des DAGs peuvent varier pour d'autres raisons. Ici on compare juste les tasks concernées par ce changement.
