### PR TITLE
refactor(bodacc): separate radiations and procédures collectives

### DIFF
--- a/config.py
+++ b/config.py
@@ -21,6 +21,7 @@ class DataSourceConfig:
             - resource_id (str, None): Data.gouv resource ID.
             - dataset_id (str, None): Data.gouv dataset ID (the most recent resource will be downloaded).
             - destination (str, None): Local path where the downloaded file will be saved.
+            - huwise (bool, None): To set at true if the dataset is from Huwise.
         url_object_storage (str | None): Object storage URL where the processed file will be stored. Defaults to None.
         url_object_storage_metadata (str | None): Object storage URL whe_object_storage metadata file will be stored. Defaults to None.
         file_output (str | None): Local file path of the output file. Defaults to None.
@@ -36,7 +37,7 @@ class DataSourceConfig:
     tmp_folder: str
     object_storage_path: str
     file_name: str | None = None
-    files_to_download: dict[str, dict[str, str]] = field(default_factory=dict)
+    files_to_download: dict[str, dict[str, str | bool]] = field(default_factory=dict)
     url_object_storage: str | None = None
     url_object_storage_metadata: str | None = None
     file_output: str | None = None

--- a/tests/unit_tests/test_bodacc.py
+++ b/tests/unit_tests/test_bodacc.py
@@ -3,18 +3,22 @@ import json
 import pandas as pd
 import pytest
 
+from data_pipelines_annuaire.workflows.data_pipelines.bodacc.procedures_collectives import (
+    _apply_procedure_collective_rules,
+    _is_cloture,
+    _load_procedure_collective_rules,
+    _parse_jugement_json,
+)
+from data_pipelines_annuaire.workflows.data_pipelines.bodacc.radiations import (
+    _parse_radiation_json,
+)
 from data_pipelines_annuaire.workflows.data_pipelines.bodacc.utils import (
-    apply_procedure_collective_rules,
+    _extract_sirens_from_personne,
     extract_sirens_from_listepersonnes,
-    extract_sirens_from_personne,
     fix_mojibake,
     get_previous_ids_to_discard,
     get_processed_ids_to_discard,
-    is_cloture,
-    load_procedure_collective_rules,
     parse_date_bodacc,
-    parse_jugement_json,
-    parse_radiation_json,
     process_discarded_announcements,
 )
 
@@ -56,35 +60,35 @@ def test_parse_date_bodacc(input, expected):
     assert parse_date_bodacc(input) == expected
 
 
-# parse_radiation_json()
+# _parse_radiation_json()
 
 
 def test_parse_radiation_json_pp():
     assert (
-        parse_radiation_json('{"dateCessationActivitePP": "2022-01-27"}')
+        _parse_radiation_json('{"dateCessationActivitePP": "2022-01-27"}')
         == "2022-01-27"
     )
 
 
 def test_parse_radiation_json_pp_legacy():
     data = '{"radiationPP": {"dateCessationActivitePP": "2019-06-15"}}'
-    assert parse_radiation_json(data) == "2019-06-15"
+    assert _parse_radiation_json(data) == "2019-06-15"
 
 
 def test_parse_radiation_json_pm_no_date():
-    assert parse_radiation_json("{}") == ""
+    assert _parse_radiation_json("{}") == ""
 
 
 def test_parse_radiation_json_empty():
-    assert parse_radiation_json("") == ""
+    assert _parse_radiation_json("") == ""
 
 
-# parse_jugement_json()
+# _parse_jugement_json()
 
 
 def test_parse_jugement_json_full():
     data = '{"famille": "Ouverture", "nature": "Redressement judiciaire", "date": "2024-07-24"}'
-    assert parse_jugement_json(data) == {
+    assert _parse_jugement_json(data) == {
         "famille": "Ouverture",
         "nature": "Redressement judiciaire",
         "complementJugement": "",
@@ -94,12 +98,12 @@ def test_parse_jugement_json_full():
 
 def test_parse_jugement_json_date_converted():
     data = '{"famille": "Ouverture", "nature": "Redressement judiciaire", "date": "27/11/2008"}'
-    result = parse_jugement_json(data)
+    result = _parse_jugement_json(data)
     assert result["date"] == "2008-11-27"
 
 
 def test_parse_jugement_json_missing_keys():
-    assert parse_jugement_json("{}") == {
+    assert _parse_jugement_json("{}") == {
         "famille": "",
         "nature": "",
         "complementJugement": "",
@@ -108,7 +112,7 @@ def test_parse_jugement_json_missing_keys():
 
 
 def test_parse_jugement_json_invalid_json():
-    assert parse_jugement_json("not json") == {
+    assert _parse_jugement_json("not json") == {
         "famille": "",
         "nature": "",
         "complementJugement": "",
@@ -117,7 +121,7 @@ def test_parse_jugement_json_invalid_json():
 
 
 def test_parse_jugement_json_empty():
-    assert parse_jugement_json("") == {
+    assert _parse_jugement_json("") == {
         "famille": "",
         "nature": "",
         "complementJugement": "",
@@ -127,7 +131,7 @@ def test_parse_jugement_json_empty():
 
 def test_parse_jugement_json_fixes_mojibake():
     data = '{"famille": "Jugement de clÃ´ture", "nature": "Jugement de clÃ´ture pour insuffisance d\'actif", "date": "2024-01-15"}'
-    result = parse_jugement_json(data)
+    result = _parse_jugement_json(data)
     assert result["famille"] == "Jugement de clôture"
     assert result["nature"] == "Jugement de clôture pour insuffisance d'actif"
 
@@ -298,19 +302,13 @@ def test_filter_discarded_keeps_normal_rectificatif_with_radiationaurcs():
 
 
 def _apply_expiration_logic(df: pd.DataFrame) -> pd.DataFrame:
-    """Reproduit la logique d'expiration de _process_procedures_collectives."""
-    df["procedure_collective_date"] = pd.to_datetime(
-        df["procedure_collective_date"], errors="coerce", format="%Y-%m-%d"
-    )
-    df["is_cloture"] = df["procedure_collective_famille"].apply(is_cloture)
+    """Reproduit la logique d'expiration de process_procedures_collectives."""
+    df["date"] = pd.to_datetime(df["date"], errors="coerce", format="%Y-%m-%d")
+    df["is_cloture"] = df["procedure_collective_famille"].apply(_is_cloture)
     ten_years_ago = pd.Timestamp.now() - pd.DateOffset(years=10)
-    df["is_expired"] = df["procedure_collective_date"] < ten_years_ago
-    df["procedure_collective_nature"] = df.apply(
-        lambda row: (
-            ""
-            if row["is_cloture"] or row["is_expired"]
-            else row["procedure_collective_nature"]
-        ),
+    df["is_expired"] = df["date"] < ten_years_ago
+    df["nature"] = df.apply(
+        lambda row: "" if row["is_cloture"] or row["is_expired"] else row["nature"],
         axis=1,
     )
     return df
@@ -320,76 +318,76 @@ def test_procedure_older_than_10_years_has_no_nature():
     df = pd.DataFrame(
         {
             "procedure_collective_famille": ["Ouverture"],
-            "procedure_collective_nature": ["Redressement judiciaire"],
-            "procedure_collective_date": ["2010-01-01"],
+            "nature": ["Redressement judiciaire"],
+            "date": ["2010-01-01"],
         }
     )
     result = _apply_expiration_logic(df)
-    assert result["procedure_collective_nature"].iloc[0] == ""
+    assert result["nature"].iloc[0] == ""
 
 
 def test_recent_procedure_keeps_nature():
     df = pd.DataFrame(
         {
             "procedure_collective_famille": ["Ouverture"],
-            "procedure_collective_nature": ["Redressement judiciaire"],
-            "procedure_collective_date": ["2024-01-01"],
+            "nature": ["Redressement judiciaire"],
+            "date": ["2024-01-01"],
         }
     )
     result = _apply_expiration_logic(df)
-    assert result["procedure_collective_nature"].iloc[0] == "Redressement judiciaire"
+    assert result["nature"].iloc[0] == "Redressement judiciaire"
 
 
 def test_cloture_procedure_has_no_nature_regardless_of_age():
     df = pd.DataFrame(
         {
             "procedure_collective_famille": ["Jugement de clôture"],
-            "procedure_collective_nature": ["Liquidation judiciaire"],
-            "procedure_collective_date": ["2024-01-01"],
+            "nature": ["Liquidation judiciaire"],
+            "date": ["2024-01-01"],
         }
     )
     result = _apply_expiration_logic(df)
-    assert result["procedure_collective_nature"].iloc[0] == ""
+    assert result["nature"].iloc[0] == ""
 
 
-# apply_procedure_collective_rules()
+# _apply_procedure_collective_rules()
 
 
 @pytest.fixture
 def rules():
-    return load_procedure_collective_rules()
+    return _load_procedure_collective_rules()
 
 
 def test_rules_liquidation_judiciaire(rules):
-    statut = apply_procedure_collective_rules(
+    statut = _apply_procedure_collective_rules(
         "Jugement d'ouverture de liquidation judiciaire", "", rules
     )
     assert statut == "liquidation_judiciaire"
 
 
 def test_rules_redressement_judiciaire(rules):
-    statut = apply_procedure_collective_rules(
+    statut = _apply_procedure_collective_rules(
         "Jugement d'ouverture d'une procédure de redressement judiciaire", "", rules
     )
     assert statut == "redressement_judiciaire"
 
 
 def test_rules_sauvegarde(rules):
-    statut = apply_procedure_collective_rules(
+    statut = _apply_procedure_collective_rules(
         "Jugement d'ouverture d'une procédure de sauvegarde", "", rules
     )
     assert statut == "sauvegarde"
 
 
 def test_rules_cloture_returns_none(rules):
-    statut = apply_procedure_collective_rules(
+    statut = _apply_procedure_collective_rules(
         "Jugement de clôture pour insuffisance d'actif", "", rules
     )
     assert statut is None
 
 
 def test_rules_autre_jugement_with_complement(rules):
-    statut = apply_procedure_collective_rules(
+    statut = _apply_procedure_collective_rules(
         "Autre jugement prononçant",
         "la clôture de la procédure pour insuffisance d'actif",
         rules,
@@ -398,7 +396,7 @@ def test_rules_autre_jugement_with_complement(rules):
 
 
 def test_rules_autre_jugement_with_complement_liquidation(rules):
-    statut = apply_procedure_collective_rules(
+    statut = _apply_procedure_collective_rules(
         "Autre jugement prononçant",
         "l'ouverture d'une procédure de liquidation judiciaire",
         rules,
@@ -407,13 +405,13 @@ def test_rules_autre_jugement_with_complement_liquidation(rules):
 
 
 def test_rules_unknown_nature_returns_none(rules):
-    statut = apply_procedure_collective_rules("Nature inconnue", "", rules)
+    statut = _apply_procedure_collective_rules("Nature inconnue", "", rules)
     assert statut is None
 
 
 def test_rules_empty_nature():
-    rules = load_procedure_collective_rules()
-    assert apply_procedure_collective_rules("", "", rules) is None
+    rules = _load_procedure_collective_rules()
+    assert _apply_procedure_collective_rules("", "", rules) is None
 
 
 # extract_sirens_from_personne()
@@ -447,7 +445,7 @@ def test_extract_sirens_rcs_and_rm():
             ]
         }
     )
-    assert extract_sirens_from_personne(data) == [
+    assert _extract_sirens_from_personne(data) == [
         "481738821",
         "510784887",
         "424557189",
@@ -473,15 +471,15 @@ def test_extract_sirens_deduplicates():
             ]
         }
     )
-    assert extract_sirens_from_personne(data) == ["123456789"]
+    assert _extract_sirens_from_personne(data) == ["123456789"]
 
 
 def test_extract_sirens_empty_json():
-    assert extract_sirens_from_personne("{}") == []
+    assert _extract_sirens_from_personne("{}") == []
 
 
 def test_extract_sirens_invalid_json():
-    assert extract_sirens_from_personne("not json") == []
+    assert _extract_sirens_from_personne("not json") == []
 
 
 def test_extract_sirens_missing_identification():
@@ -492,7 +490,7 @@ def test_extract_sirens_missing_identification():
             ]
         }
     )
-    assert extract_sirens_from_personne(data) == []
+    assert _extract_sirens_from_personne(data) == []
 
 
 def test_extract_sirens_single_personne_not_list():
@@ -506,7 +504,7 @@ def test_extract_sirens_single_personne_not_list():
             }
         }
     )
-    assert extract_sirens_from_personne(data) == ["111222333"]
+    assert _extract_sirens_from_personne(data) == ["111222333"]
 
 
 # extract_sirens_from_listepersonnes()

--- a/workflows/data_pipelines/bodacc/config.py
+++ b/workflows/data_pipelines/bodacc/config.py
@@ -7,7 +7,6 @@ BODACC_CONFIG = DataSourceConfig(
     name="bodacc",
     tmp_folder=f"{DataSourceConfig.base_tmp_folder}/bodacc",
     object_storage_path="bodacc",
-    file_name="bodacc",
     files_to_download={
         "procedures_collectives": {
             "huwise": True,
@@ -20,67 +19,90 @@ BODACC_CONFIG = DataSourceConfig(
             "destination": f"{DataSourceConfig.base_tmp_folder}/bodacc/radiations-raw.csv",
         },
     },
-    url_object_storage=f"{OBJECT_STORAGE_BASE_URL}bodacc/latest/bodacc.csv",
-    url_object_storage_metadata=f"{OBJECT_STORAGE_BASE_URL}bodacc/latest/metadata.json",
-    # radiation_visibility et radiation_visibility_reason sont alimentés par la
-    # task de postprocessing dans le DAG d'ETL pour masquer certaines radiations
+)
+
+RADIATIONS_CONFIG = DataSourceConfig(
+    name="bodacc_radiations",
+    tmp_folder=BODACC_CONFIG.tmp_folder,
+    object_storage_path=f"{BODACC_CONFIG.object_storage_path}/radiations",
+    file_name="radiations",
+    url_object_storage=f"{OBJECT_STORAGE_BASE_URL}bodacc/radiations/latest/radiations.csv",
+    url_object_storage_metadata=f"{OBJECT_STORAGE_BASE_URL}bodacc/radiations/latest/metadata.json",
     table_ddl="""
         BEGIN;
-        CREATE TABLE IF NOT EXISTS bodacc
+        CREATE TABLE IF NOT EXISTS bodacc_radiations
         (
             siren TEXT PRIMARY KEY,
-            radiation_id_annonce TEXT,
-            radiation_est_radie INTEGER,
-            radiation_date DATE,
-            radiation_date_publication DATE,
-            procedure_collective_id_annonce TEXT,
-            procedure_collective_statut TEXT,
-            procedure_collective_nature TEXT,
-            procedure_collective_complement TEXT,
-            procedure_collective_date DATE,
-            procedure_collective_date_publication DATE,
+            id_annonce TEXT,
+            est_radie INTEGER,
+            date DATE,
+            date_publication DATE,
 
-            procedure_collective_cloturee_nature TEXT,
-
-            radiation_visibility INTEGER DEFAULT 1,
-            radiation_visibility_reason TEXT DEFAULT 'visible_by_default'
+            visibility INTEGER DEFAULT 1,
+            visibility_reason TEXT DEFAULT 'visible_by_default'
         );
         COMMIT;
     """,
     post_processing_queries=[
         """
-            UPDATE bodacc
-            SET radiation_visibility = 0,
-                radiation_visibility_reason = 'ei_active_on_sirene'
-            WHERE bodacc.radiation_est_radie
+            UPDATE bodacc_radiations
+            SET visibility = 0,
+                visibility_reason = 'ei_active_on_sirene'
+            WHERE bodacc_radiations.est_radie
             AND siren IN (
                 SELECT ul.siren
                 FROM unite_legale AS ul
                 INNER JOIN etablissement AS e ON e.siren = ul.siren
-                WHERE bodacc.siren = ul.siren
+                WHERE bodacc_radiations.siren = ul.siren
                 AND ul.nature_juridique_unite_legale = '1000'
                 AND ul.etat_administratif_unite_legale = 'A'
                 AND e.etat_administratif_etablissement = 'A'
             )
             """,
+        # radiation_visibility et radiation_visibility_reason sont alimentés par la
+        # task de postprocessing dans le DAG d'ETL pour masquer les radiations correspondantes
         """
-            UPDATE bodacc
-            SET radiation_visibility = 0,
-                radiation_visibility_reason = 'ei_with_new_etab_since_radiation'
-            WHERE bodacc.radiation_est_radie
+            UPDATE bodacc_radiations
+            SET visibility = 0,
+                visibility_reason = 'ei_with_new_etab_since_radiation'
+            WHERE bodacc_radiations.est_radie
             AND siren IN (
                 SELECT ul.siren
                 FROM unite_legale AS ul
                 INNER JOIN etablissement AS e ON e.siren = ul.siren
                 left join immatriculation AS i on i.siren = ul.siren
-                WHERE bodacc.siren = ul.siren
+                WHERE bodacc_radiations.siren = ul.siren
                 AND ul.nature_juridique_unite_legale = '1000'
                 AND (
-                    e.date_creation >= bodacc.radiation_date
-                 OR e.date_debut_activite >= bodacc.radiation_date
-                 OR i.date_immatriculation >= bodacc.radiation_date
+                    e.date_creation >= bodacc_radiations.date
+                 OR e.date_debut_activite >= bodacc_radiations.date
+                 OR i.date_immatriculation >= bodacc_radiations.date
                  )
             )
             """,
     ],
+)
+
+PROCEDURES_COLLECTIVES_CONFIG = DataSourceConfig(
+    name="bodacc_procedures_collectives",
+    tmp_folder=BODACC_CONFIG.tmp_folder,
+    object_storage_path=f"{BODACC_CONFIG.object_storage_path}/procedures_collectives",
+    file_name="procedures_collectives",
+    url_object_storage=f"{OBJECT_STORAGE_BASE_URL}bodacc/procedures_collectives/latest/procedures_collectives.csv",
+    url_object_storage_metadata=f"{OBJECT_STORAGE_BASE_URL}bodacc/procedures_collectives/latest/metadata.json",
+    table_ddl="""
+        BEGIN;
+        CREATE TABLE IF NOT EXISTS bodacc_procedures_collectives
+        (
+            siren TEXT PRIMARY KEY,
+            id_annonce TEXT,
+            statut TEXT,
+            nature TEXT,
+            complement TEXT,
+            date DATE,
+            date_publication DATE,
+            cloturee_nature TEXT
+        );
+        COMMIT;
+    """,
 )

--- a/workflows/data_pipelines/bodacc/dag.py
+++ b/workflows/data_pipelines/bodacc/dag.py
@@ -38,8 +38,12 @@ def data_processing_bodacc():
         return bodacc_processor.download_data()
 
     @task
-    def preprocess_data():
-        return bodacc_processor.preprocess_data()
+    def preprocess_radiations():
+        return bodacc_processor.preprocess_radiations()
+
+    @task
+    def preprocess_procedures_collectives():
+        return bodacc_processor.preprocess_procedures_collectives()
 
     @task
     def save_date_last_modified():
@@ -56,7 +60,7 @@ def data_processing_bodacc():
     return (
         clean_previous_outputs()
         >> download_data()
-        >> preprocess_data()
+        >> [preprocess_radiations(), preprocess_procedures_collectives()]
         >> save_date_last_modified()
         >> send_file_to_object_storage()
         >> compare_files_object_storage()

--- a/workflows/data_pipelines/bodacc/procedures_collectives.py
+++ b/workflows/data_pipelines/bodacc/procedures_collectives.py
@@ -1,0 +1,259 @@
+import json
+import logging
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from data_pipelines_annuaire.helpers.data_quality import clean_sirent_column
+from data_pipelines_annuaire.workflows.data_pipelines.bodacc.utils import (
+    extract_sirens_from_listepersonnes,
+    fix_mojibake,
+    parse_date_bodacc,
+    process_discarded_announcements,
+)
+
+_INPUT_COLUMNS = [
+    "id",
+    "listepersonnes",
+    "dateparution",
+    "typeavis",
+    "jugement",
+    "parutionavisprecedent",
+]
+
+_OUTPUT_COLUMNS = [
+    "siren",
+    "id_annonce",
+    "statut",
+    "nature",
+    "complement",
+    "date",
+    "date_publication",
+    "cloturee_nature",
+]
+
+_RULES_PATH = Path(__file__).parent / "rule.yml"
+
+
+def _load_procedure_collective_rules() -> list[dict]:
+    with open(_RULES_PATH, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return data["procedure_collective_rules"]
+
+
+def _apply_procedure_collective_rules(
+    nature: str, complement_jugement: str, rules: list[dict]
+) -> str | None:
+    """
+    Applique les règles dans l'ordre. Retourne le statut de la première règle
+    qui matche, ou None si aucune règle ne correspond (avec un warning loggé).
+    """
+    if not nature:
+        return None
+
+    for rule in rules:
+        if rule["nature"] != nature:
+            continue
+        if "complement_contains" in rule:
+            if (
+                not complement_jugement
+                or rule["complement_contains"].lower()
+                not in complement_jugement.lower()
+            ):
+                continue
+        return rule.get("statut")
+
+    logging.warning(f"BODACC: nature non traitée dans rule.yml : '{nature}'")
+    return None
+
+
+def _is_cloture(famille: str) -> bool:
+    """Vérifie si la famille correspond à une clôture de procédure."""
+    FAMILLES_CLOTURE = [
+        "jugement de clôture",
+    ]
+    if pd.isna(famille) or not famille:
+        return False
+    famille_lower = famille.lower()
+    return any(kw in famille_lower for kw in FAMILLES_CLOTURE)
+
+
+def _parse_jugement_json(jugement_str: str) -> dict:
+    """Parse le champ json jugement et en extraire famille, nature, complementJugement et date."""
+    if pd.isna(jugement_str) or not jugement_str:
+        return {"famille": "", "nature": "", "complementJugement": "", "date": ""}
+    try:
+        data = json.loads(jugement_str)
+        return {
+            "famille": fix_mojibake(data.get("famille", "")),
+            "nature": fix_mojibake(data.get("nature", "")),
+            "complementJugement": fix_mojibake(data.get("complementJugement", "")),
+            "date": parse_date_bodacc(data.get("date", "")),
+        }
+    except json.JSONDecodeError:
+        return {"famille": "", "nature": "", "complementJugement": "", "date": ""}
+
+
+def _process_procedure_chunk(chunk: pd.DataFrame) -> pd.DataFrame:
+    """Traiter un chunk de données procédures collectives."""
+    # Un avis de procédure collective peut concerner qu'une ou plusieurs "personnes"
+    chunk = extract_sirens_from_listepersonnes(chunk)
+
+    # Nettoyer et valider les SIREN
+    chunk = clean_sirent_column(
+        chunk,
+        column_type="siren",
+        column_name="siren",
+        add_leading_zeros=True,
+        max_removal_percentage=0.1,
+    )
+
+    if chunk.empty:
+        return chunk
+
+    # Parser le JSON jugement (famille, nature, date)
+    chunk["jugement_parsed"] = chunk["jugement"].apply(_parse_jugement_json)
+    chunk["procedure_collective_famille"] = chunk["jugement_parsed"].apply(
+        lambda x: x.get("famille", "") if x else ""
+    )
+
+    # Ces familles ne représentent pas des procédures collectives à proprement parler :
+    # - "Avis de dépôt" : simple formalité de dépôt de créances
+    # - "Extrait de jugement" : cas marginaux mal catégorisés
+    # - "Loi de 1967" : régime juridique obsolète
+    familles_exclues = ["Avis de dépôt", "Extrait de jugement", "Loi de 1967"]
+    chunk = chunk[~chunk["procedure_collective_famille"].isin(familles_exclues)]
+
+    if chunk.empty:
+        return chunk
+
+    chunk["nature"] = chunk["jugement_parsed"].apply(
+        lambda x: x.get("nature", "") if x else ""
+    )
+    chunk["complement"] = chunk["jugement_parsed"].apply(
+        lambda x: x.get("complementJugement", "") if x else ""
+    )
+    chunk["date"] = chunk["jugement_parsed"].apply(
+        lambda x: x.get("date", "") if x else ""
+    )
+
+    # Garder uniquement les colonnes nécessaires
+    chunk["date_publication"] = chunk["dateparution"]
+    chunk["id_annonce"] = chunk["id"]
+    return chunk[
+        [
+            "siren",
+            "id_annonce",
+            "procedure_collective_famille",
+            "nature",
+            "complement",
+            "date",
+            "date_publication",
+        ]
+    ]
+
+
+def process_procedures_collectives(raw_file_path: str, chunk_size: int) -> pd.DataFrame:
+    logging.info("Processing procédures collectives...")
+    chunks_processed = []
+
+    # Charger le fichier complet pour gérer les annulations
+    df_full = pd.read_csv(
+        raw_file_path,
+        dtype=str,
+        sep=";",
+        usecols=_INPUT_COLUMNS,
+    )
+    logging.info(f"Loaded {len(df_full)} procedure rows")
+
+    # Filtrer les annulations et rétractations
+    df_full = process_discarded_announcements(df_full)
+    logging.info(f"After filtering cancellations: {len(df_full)} rows")
+
+    # Traiter par chunks pour la mémoire
+    for i in range(0, len(df_full), chunk_size):
+        chunk = df_full.iloc[i : i + chunk_size]
+        processed = _process_procedure_chunk(chunk)
+        if not processed.empty:
+            chunks_processed.append(processed)
+
+    if not chunks_processed:
+        logging.warning("No procedures collectives found")
+        return pd.DataFrame(columns=_OUTPUT_COLUMNS)
+
+    # Concaténer tous les chunks
+    df = pd.concat(chunks_processed, ignore_index=True)
+
+    # Appliquer les règles de classification
+    rules = _load_procedure_collective_rules()
+    df["statut"] = df.apply(
+        lambda row: _apply_procedure_collective_rules(
+            row["nature"],
+            row["complement"],
+            rules,
+        ),
+        axis=1,
+    )
+
+    # Environ 5 dates de procédures collectives avec des dates absurdes comme 0009-12-02 ou 5025-05-27
+    # Ces "erreurs" sont ignorées lors des conversions en datetime
+    df["date"] = pd.to_datetime(df["date"], errors="coerce", format="%Y-%m-%d")
+    df["date_publication"] = pd.to_datetime(
+        df["date_publication"],
+        errors="coerce",
+        format="%Y-%m-%d",
+    )
+
+    # Dédupliquer par SIREN en gardant la procédure la plus récente
+    df = df.sort_values(
+        [
+            "date",
+            "date_publication",
+        ],
+        ascending=[False, False],
+    )
+    duplicated_mask = df.duplicated(subset=["siren"], keep="first")
+    n_duplicates = duplicated_mask.sum()
+    if n_duplicates > 0:
+        sample_sirens = df.loc[duplicated_mask, "siren"].head(5).tolist()
+        logging.info(
+            f"Procedures: {n_duplicates} duplicate Siren, sample:\n{sample_sirens}"
+        )
+    df = df.drop_duplicates(subset=["siren"], keep="first")
+
+    # Si le dernier jugement est une clôture, la procédure n'est plus active.
+    df["is_cloture"] = df["procedure_collective_famille"].apply(_is_cloture)
+
+    # Au-delà de 10 ans sans nouveau jugement, on considère la procédure
+    # comme expirée. C'est une règle de précaution car les procédures
+    # ne sont pss censées durer aussi longtemps.
+    ten_years_ago = pd.Timestamp.now() - pd.DateOffset(years=10)
+    df["is_expired"] = df["date"] < ten_years_ago
+
+    # Créer les colonnes finales
+    df["cloturee_nature"] = df.apply(
+        lambda row: row["nature"] if row["is_cloture"] else "",
+        axis=1,
+    )
+    df["nature"] = df.apply(
+        lambda row: "" if row["is_cloture"] or row["is_expired"] else row["nature"],
+        axis=1,
+    )
+
+    # Effacer le statut pour les procédures clôturées ou expirées
+    df["statut"] = df.apply(
+        lambda row: (
+            "" if row["is_cloture"] or row["is_expired"] else row["statut"] or ""
+        ),
+        axis=1,
+    )
+
+    logging.info(
+        f"Procedures: {len(df)} unique SIRENs, "
+        f"{df['is_cloture'].sum()} clôturées, "
+        f"{(~df['is_cloture'] & df['is_expired']).sum()} expirées (>10 ans), "
+        f"{(~df['is_cloture'] & ~df['is_expired']).sum()} en cours"
+    )
+
+    return df[_OUTPUT_COLUMNS]

--- a/workflows/data_pipelines/bodacc/processor.py
+++ b/workflows/data_pipelines/bodacc/processor.py
@@ -1,382 +1,76 @@
 import logging
 
-import pandas as pd
-
 from data_pipelines_annuaire.helpers import (
     DataProcessor,
     Notification,
 )
-from data_pipelines_annuaire.helpers.data_quality import clean_sirent_column
 from data_pipelines_annuaire.workflows.data_pipelines.bodacc.config import (
     BODACC_CONFIG,
+    PROCEDURES_COLLECTIVES_CONFIG,
+    RADIATIONS_CONFIG,
 )
-from data_pipelines_annuaire.workflows.data_pipelines.bodacc.utils import (
-    apply_procedure_collective_rules,
-    extract_sirens_from_listepersonnes,
-    is_cloture,
-    load_procedure_collective_rules,
-    parse_jugement_json,
-    parse_radiation_json,
-    process_discarded_announcements,
+from data_pipelines_annuaire.workflows.data_pipelines.bodacc.procedures_collectives import (
+    process_procedures_collectives,
 )
-
-logger = logging.getLogger(__name__)
-
-
-def process_radiation_chunk(chunk: pd.DataFrame) -> pd.DataFrame:
-    """Traiter un chunk de données radiations."""
-    # Un avis de radiation ne concerne à chaque fois qu'une seule "personne"
-    # Quelques rares cas ont cependant plusieurs objets "personne"
-    # Mais ils partagent à chaque fois le même siren, ainsi après déduplication
-    # on se retrouve tout de même avec une seule "personne" par annonce
-    chunk = extract_sirens_from_listepersonnes(chunk)
-
-    # Nettoyer et valider les SIREN
-    chunk = clean_sirent_column(
-        chunk,
-        column_type="siren",
-        column_name="siren",
-        add_leading_zeros=True,
-        max_removal_percentage=0.1,
-    )
-
-    if chunk.empty:
-        return chunk
-
-    # Parser le JSON radiationaurcs pour extraire la date
-    chunk["radiation_date"] = chunk["radiationaurcs"].apply(parse_radiation_json)
-
-    # Marquer comme radié (présent dans le fichier = radié)
-    chunk["radiation_est_radie"] = 1
-
-    # Garder uniquement les colonnes nécessaires
-    chunk["radiation_date_publication"] = chunk["dateparution"]
-    chunk["radiation_id_annonce"] = chunk["id"]
-    return chunk[
-        [
-            "siren",
-            "radiation_id_annonce",
-            "radiation_est_radie",
-            "radiation_date",
-            "radiation_date_publication",
-        ]
-    ]
-
-
-def process_procedure_chunk(chunk: pd.DataFrame) -> pd.DataFrame:
-    """Traiter un chunk de données procédures collectives."""
-    # Un avis de procédure collective peut concerner qu'une ou plusieurs "personnes"
-    chunk = extract_sirens_from_listepersonnes(chunk)
-
-    # Nettoyer et valider les SIREN
-    chunk = clean_sirent_column(
-        chunk,
-        column_type="siren",
-        column_name="siren",
-        add_leading_zeros=True,
-        max_removal_percentage=0.1,
-    )
-
-    if chunk.empty:
-        return chunk
-
-    # Parser le JSON jugement (famille, nature, date)
-    chunk["jugement_parsed"] = chunk["jugement"].apply(parse_jugement_json)
-    chunk["procedure_collective_famille"] = chunk["jugement_parsed"].apply(
-        lambda x: x.get("famille", "") if x else ""
-    )
-
-    # Ces familles ne représentent pas des procédures collectives à proprement parler :
-    # - "Avis de dépôt" : simple formalité de dépôt de créances
-    # - "Extrait de jugement" : cas marginaux mal catégorisés
-    # - "Loi de 1967" : régime juridique obsolète
-    familles_exclues = ["Avis de dépôt", "Extrait de jugement", "Loi de 1967"]
-    chunk = chunk[~chunk["procedure_collective_famille"].isin(familles_exclues)]
-
-    if chunk.empty:
-        return chunk
-
-    chunk["procedure_collective_nature"] = chunk["jugement_parsed"].apply(
-        lambda x: x.get("nature", "") if x else ""
-    )
-    chunk["procedure_collective_complement"] = chunk["jugement_parsed"].apply(
-        lambda x: x.get("complementJugement", "") if x else ""
-    )
-    chunk["procedure_collective_date"] = chunk["jugement_parsed"].apply(
-        lambda x: x.get("date", "") if x else ""
-    )
-
-    # Garder uniquement les colonnes nécessaires
-    chunk["procedure_collective_date_publication"] = chunk["dateparution"]
-    chunk["procedure_collective_id_annonce"] = chunk["id"]
-    return chunk[
-        [
-            "siren",
-            "procedure_collective_id_annonce",
-            "procedure_collective_famille",
-            "procedure_collective_nature",
-            "procedure_collective_complement",
-            "procedure_collective_date",
-            "procedure_collective_date_publication",
-        ]
-    ]
+from data_pipelines_annuaire.workflows.data_pipelines.bodacc.radiations import (
+    process_radiations,
+)
 
 
 class BodaccProcessor(DataProcessor):
     CHUNK_SIZE = 100_000
 
-    COLUMNS_RADIATIONS = (
-        "id",
-        "listepersonnes",
-        "dateparution",
-        "typeavis",
-        "radiationaurcs",
-        "parutionavisprecedent",
-    )
-    COLUMNS_PROCEDURES = (
-        "id",
-        "listepersonnes",
-        "dateparution",
-        "typeavis",
-        "jugement",
-        "parutionavisprecedent",
-    )
-
     def __init__(self):
         super().__init__(BODACC_CONFIG)
+        # Radiations et procédures collectives partagent le même tmp_folder mais
+        # produisent chacune leur propre CSV : on délègue l'envoi et la
+        # comparaison à un DataProcessor par sous-source.
+        self._sub_processors = [
+            DataProcessor(RADIATIONS_CONFIG),
+            DataProcessor(PROCEDURES_COLLECTIVES_CONFIG),
+        ]
 
-    def preprocess_data(self):
-        logger.info("Processing BODACC data...")
-
-        df_radiations = self._process_radiations()
-        logger.info(f"Radiations: {len(df_radiations)} unique SIRENs")
-
-        df_procedures = self._process_procedures_collectives()
-        logger.info(f"Procédures collectives: {len(df_procedures)} unique SIRENs")
-
-        df = pd.merge(
-            df_radiations,
-            df_procedures,
-            on="siren",
-            how="outer",
+    def preprocess_radiations(self):
+        logging.info("Processing BODACC radiations...")
+        df = process_radiations(
+            self.config.files_to_download["radiations"]["destination"],
+            self.CHUNK_SIZE,
         )
-        logger.info(f"After merge: {len(df)} unique SIRENs")
-        df.to_csv(f"{self.config.tmp_folder}/{self.config.file_name}.csv", index=False)
-
+        logging.info(f"Radiations: {len(df)} unique SIRENs")
+        df.to_csv(
+            f"{self.config.tmp_folder}/{RADIATIONS_CONFIG.file_name}.csv", index=False
+        )
         DataProcessor.push_message(
             Notification.notification_xcom_key,
-            description=f"{len(df)} SIREN traités au BODACC<ul><li>radiations : {len(df_radiations)}</li><li>procédures collectives : {len(df_procedures)}</li></ul>",
+            description=f"radiations BODACC : {len(df)} SIREN",
         )
 
-    def _process_radiations(self) -> pd.DataFrame:
-        logger.info("Processing radiations...")
-        chunks_processed = []
-        total_rows = 0
-
-        # Charger le fichier complet pour gérer les annulations
-        df_full = pd.read_csv(
-            self.config.files_to_download["radiations"]["destination"],
-            dtype=str,
-            sep=";",
-            usecols=self.COLUMNS_RADIATIONS,
-        )
-        total_rows = len(df_full)
-        logger.info(f"Loaded {total_rows} radiation rows")
-
-        # Filtrer les annulations
-        df_full = process_discarded_announcements(df_full)
-        logger.info(f"After filtering cancellations: {len(df_full)} rows")
-
-        # Traiter par chunks pour la mémoire
-        for i in range(0, len(df_full), self.CHUNK_SIZE):
-            chunk = df_full.iloc[i : i + self.CHUNK_SIZE]
-            processed = process_radiation_chunk(chunk)
-            if not processed.empty:
-                chunks_processed.append(processed)
-
-        if not chunks_processed:
-            logger.warning("No radiations found")
-            return pd.DataFrame(
-                columns=[
-                    "siren",
-                    "radiation_id_annonce",
-                    "radiation_est_radie",
-                    "radiation_date",
-                    "radiation_date_publication",
-                ]
-            )
-
-        # Concaténer tous les chunks
-        df = pd.concat(chunks_processed, ignore_index=True)
-
-        # Environ 109 dates de radiations avec des dates absurdes comme 1213-10-03 ou 5019-06-01
-        # Ces "erreurs" sont ignorées lors des conversions en datetime
-        df["radiation_date"] = pd.to_datetime(
-            df["radiation_date"], errors="coerce", format="%Y-%m-%d"
-        )
-        df["radiation_date_publication"] = pd.to_datetime(
-            df["radiation_date_publication"], errors="coerce", format="%Y-%m-%d"
-        )
-
-        # Dédupliquer par Siren en gardant la radiation la plus récente
-        df = df.sort_values(
-            ["radiation_date", "radiation_date_publication"],
-            ascending=[False, False],
-        )
-        duplicated_mask = df.duplicated(subset=["siren"], keep="first")
-        n_duplicates = duplicated_mask.sum()
-        if n_duplicates > 0:
-            sample_sirens = df.loc[duplicated_mask, "siren"].head(5).tolist()
-            logger.info(
-                f"Radiations: {n_duplicates} duplicate Siren, sample:\n{sample_sirens}"
-            )
-        df = df.drop_duplicates(subset=["siren"], keep="first")
-
-        return df[
-            [
-                "siren",
-                "radiation_id_annonce",
-                "radiation_est_radie",
-                "radiation_date",
-                "radiation_date_publication",
-            ]
-        ]
-
-    def _process_procedures_collectives(self) -> pd.DataFrame:
-        logger.info("Processing procédures collectives...")
-        chunks_processed = []
-        total_rows = 0
-
-        # Charger le fichier complet pour gérer les annulations
-        df_full = pd.read_csv(
+    def preprocess_procedures_collectives(self):
+        logging.info("Processing BODACC procédures collectives...")
+        df = process_procedures_collectives(
             self.config.files_to_download["procedures_collectives"]["destination"],
-            dtype=str,
-            sep=";",
-            usecols=self.COLUMNS_PROCEDURES,
+            self.CHUNK_SIZE,
         )
-        total_rows = len(df_full)
-        logger.info(f"Loaded {total_rows} procedure rows")
-
-        # Filtrer les annulations et rétractations
-        df_full = process_discarded_announcements(df_full)
-        logger.info(f"After filtering cancellations: {len(df_full)} rows")
-
-        # Traiter par chunks pour la mémoire
-        for i in range(0, len(df_full), self.CHUNK_SIZE):
-            chunk = df_full.iloc[i : i + self.CHUNK_SIZE]
-            processed = process_procedure_chunk(chunk)
-            if not processed.empty:
-                chunks_processed.append(processed)
-
-        if not chunks_processed:
-            logger.warning("No procedures collectives found")
-            return pd.DataFrame(
-                columns=[
-                    "siren",
-                    "procedure_collective_id_annonce",
-                    "procedure_collective_statut",
-                    "procedure_collective_nature",
-                    "procedure_collective_complement",
-                    "procedure_collective_date",
-                    "procedure_collective_date_publication",
-                    "procedure_collective_cloturee_nature",
-                ]
-            )
-
-        # Concaténer tous les chunks
-        df = pd.concat(chunks_processed, ignore_index=True)
-
-        # Appliquer les règles de classification
-        rules = load_procedure_collective_rules()
-        df["procedure_collective_statut"] = df.apply(
-            lambda row: apply_procedure_collective_rules(
-                row["procedure_collective_nature"],
-                row["procedure_collective_complement"],
-                rules,
-            ),
-            axis=1,
+        logging.info(f"Procédures collectives: {len(df)} unique SIRENs")
+        df.to_csv(
+            f"{self.config.tmp_folder}/{PROCEDURES_COLLECTIVES_CONFIG.file_name}.csv",
+            index=False,
+        )
+        DataProcessor.push_message(
+            Notification.notification_xcom_key,
+            description=f"procédures collectives BODACC : {len(df)} SIREN",
         )
 
-        # Environ 5 dates de procédures collectives avec des dates absurdes comme 0009-12-02 ou 5025-05-27
-        # Ces "erreurs" sont ignorées lors des conversions en datetime
-        df["procedure_collective_date"] = pd.to_datetime(
-            df["procedure_collective_date"], errors="coerce", format="%Y-%m-%d"
-        )
-        df["procedure_collective_date_publication"] = pd.to_datetime(
-            df["procedure_collective_date_publication"],
-            errors="coerce",
-            format="%Y-%m-%d",
-        )
+    def send_file_to_object_storage(self):
+        for sub_processor in self._sub_processors:
+            sub_processor.send_file_to_object_storage()
 
-        # Dédupliquer par SIREN en gardant la procédure la plus récente
-        df = df.sort_values(
+    def compare_files_object_storage(self):
+        # Liste (et non générateur) pour comparer/uploader toutes les
+        # sous-sources sans court-circuit de any().
+        return any(
             [
-                "procedure_collective_date",
-                "procedure_collective_date_publication",
-            ],
-            ascending=[False, False],
-        )
-        duplicated_mask = df.duplicated(subset=["siren"], keep="first")
-        n_duplicates = duplicated_mask.sum()
-        if n_duplicates > 0:
-            sample_sirens = df.loc[duplicated_mask, "siren"].head(5).tolist()
-            logger.info(
-                f"Procedures: {n_duplicates} duplicate Siren, sample:\n{sample_sirens}"
-            )
-        df = df.drop_duplicates(subset=["siren"], keep="first")
-
-        # Si le dernier jugement est une clôture, la procédure n'est plus active.
-        df["is_cloture"] = df["procedure_collective_famille"].apply(is_cloture)
-
-        # Au-delà de 10 ans sans nouveau jugement, on considère la procédure
-        # comme expirée. C'est une règle de précaution car les procédures
-        # ne sont pss censées durer aussi longtemps.
-        ten_years_ago = pd.Timestamp.now() - pd.DateOffset(years=10)
-        df["is_expired"] = df["procedure_collective_date"] < ten_years_ago
-
-        # Créer les colonnes finales
-        df["procedure_collective_cloturee_nature"] = df.apply(
-            lambda row: row["procedure_collective_nature"] if row["is_cloture"] else "",
-            axis=1,
-        )
-        df["procedure_collective_nature_finale"] = df.apply(
-            lambda row: (
-                ""
-                if row["is_cloture"] or row["is_expired"]
-                else row["procedure_collective_nature"]
-            ),
-            axis=1,
-        )
-
-        # Renommer pour l'export
-        df["procedure_collective_nature"] = df["procedure_collective_nature_finale"]
-
-        # Effacer le statut pour les procédures clôturées ou expirées
-        df["procedure_collective_statut"] = df.apply(
-            lambda row: (
-                ""
-                if row["is_cloture"] or row["is_expired"]
-                else row["procedure_collective_statut"] or ""
-            ),
-            axis=1,
-        )
-
-        logger.info(
-            f"Procedures: {len(df)} unique SIRENs, "
-            f"{df['is_cloture'].sum()} clôturées, "
-            f"{(~df['is_cloture'] & df['is_expired']).sum()} expirées (>10 ans), "
-            f"{(~df['is_cloture'] & ~df['is_expired']).sum()} en cours"
-        )
-
-        return df[
-            [
-                "siren",
-                "procedure_collective_id_annonce",
-                "procedure_collective_statut",
-                "procedure_collective_nature",
-                "procedure_collective_complement",
-                "procedure_collective_date",
-                "procedure_collective_date_publication",
-                "procedure_collective_cloturee_nature",
+                sub_processor.compare_files_object_storage()
+                for sub_processor in self._sub_processors
             ]
-        ]
+        )

--- a/workflows/data_pipelines/bodacc/radiations.py
+++ b/workflows/data_pipelines/bodacc/radiations.py
@@ -1,0 +1,130 @@
+import json
+import logging
+
+import pandas as pd
+
+from data_pipelines_annuaire.helpers.data_quality import clean_sirent_column
+from data_pipelines_annuaire.workflows.data_pipelines.bodacc.utils import (
+    extract_sirens_from_listepersonnes,
+    parse_date_bodacc,
+    process_discarded_announcements,
+)
+
+_INPUT_COLUMNS = [
+    "id",
+    "listepersonnes",
+    "dateparution",
+    "typeavis",
+    "radiationaurcs",
+    "parutionavisprecedent",
+]
+
+_OUTPUT_COLUMNS = [
+    "siren",
+    "id_annonce",
+    "est_radie",
+    "date",
+    "date_publication",
+]
+
+
+def _parse_radiation_json(radiation_str: str) -> str:
+    """Extrait la date de cessation depuis le champ radiationaurcs."""
+    if pd.isna(radiation_str) or not radiation_str:
+        return ""
+    data = json.loads(radiation_str)
+    # Format acutel PP
+    if "dateCessationActivitePP" in data:
+        return parse_date_bodacc(data["dateCessationActivitePP"])
+    # Format obsolète PP
+    if "radiationPP" in data and isinstance(data["radiationPP"], dict):
+        return parse_date_bodacc(data["radiationPP"].get("dateCessationActivitePP", ""))
+    # Les PM n'ont pas de date de disponible
+    return ""
+
+
+def _process_radiation_chunk(chunk: pd.DataFrame) -> pd.DataFrame:
+    """Traiter un chunk de données radiations."""
+    # Un avis de radiation ne concerne à chaque fois qu'une seule "personne"
+    # Quelques rares cas ont cependant plusieurs objets "personne"
+    # Mais ils partagent à chaque fois le même siren, ainsi après déduplication
+    # on se retrouve tout de même avec une seule "personne" par annonce
+    chunk = extract_sirens_from_listepersonnes(chunk)
+
+    # Nettoyer et valider les SIREN
+    chunk = clean_sirent_column(
+        chunk,
+        column_type="siren",
+        column_name="siren",
+        add_leading_zeros=True,
+        max_removal_percentage=0.1,
+    )
+
+    if chunk.empty:
+        return chunk
+
+    # Parser le JSON radiationaurcs pour extraire la date
+    chunk["date"] = chunk["radiationaurcs"].apply(_parse_radiation_json)
+
+    # Marquer comme radié (présent dans le fichier = radié)
+    chunk["est_radie"] = 1
+
+    # Garder uniquement les colonnes nécessaires
+    chunk["date_publication"] = chunk["dateparution"]
+    chunk["id_annonce"] = chunk["id"]
+    return chunk[_OUTPUT_COLUMNS]
+
+
+def process_radiations(raw_file_path: str, chunk_size: int) -> pd.DataFrame:
+    logging.info("Processing radiations...")
+    chunks_processed = []
+
+    # Charger le fichier complet pour gérer les annulations
+    df_full = pd.read_csv(
+        raw_file_path,
+        dtype=str,
+        sep=";",
+        usecols=_INPUT_COLUMNS,
+    )
+    logging.info(f"Loaded {len(df_full)} radiation rows")
+
+    # Filtrer les annulations
+    df_full = process_discarded_announcements(df_full)
+    logging.info(f"After filtering cancellations: {len(df_full)} rows")
+
+    # Traiter par chunks pour la mémoire
+    for i in range(0, len(df_full), chunk_size):
+        chunk = df_full.iloc[i : i + chunk_size]
+        processed = _process_radiation_chunk(chunk)
+        if not processed.empty:
+            chunks_processed.append(processed)
+
+    if not chunks_processed:
+        logging.warning("No radiations found")
+        return pd.DataFrame(columns=_OUTPUT_COLUMNS)
+
+    # Concaténer tous les chunks
+    df = pd.concat(chunks_processed, ignore_index=True)
+
+    # Environ 109 dates de radiations avec des dates absurdes comme 1213-10-03 ou 5019-06-01
+    # Ces "erreurs" sont ignorées lors des conversions en datetime
+    df["date"] = pd.to_datetime(df["date"], errors="coerce", format="%Y-%m-%d")
+    df["date_publication"] = pd.to_datetime(
+        df["date_publication"], errors="coerce", format="%Y-%m-%d"
+    )
+
+    # Dédupliquer par Siren en gardant la radiation la plus récente
+    df = df.sort_values(
+        ["date", "date_publication"],
+        ascending=[False, False],
+    )
+    duplicated_mask = df.duplicated(subset=["siren"], keep="first")
+    n_duplicates = duplicated_mask.sum()
+    if n_duplicates > 0:
+        sample_sirens = df.loc[duplicated_mask, "siren"].head(5).tolist()
+        logging.info(
+            f"Radiations: {n_duplicates} duplicate Siren, sample:\n{sample_sirens}"
+        )
+    df = df.drop_duplicates(subset=["siren"], keep="first")
+
+    return df[_OUTPUT_COLUMNS]

--- a/workflows/data_pipelines/bodacc/utils.py
+++ b/workflows/data_pipelines/bodacc/utils.py
@@ -1,10 +1,7 @@
-import json
 import logging
 import re
-from pathlib import Path
 
 import pandas as pd
-import yaml
 
 from data_pipelines_annuaire.helpers.utils import keep_only_numbers, parse_json_safe
 
@@ -77,66 +74,7 @@ def parse_date_bodacc(date_str: str) -> str:
     return ""
 
 
-def parse_radiation_json(radiation_str: str) -> str:
-    """Extrait la date de cessation depuis le champ radiationaurcs."""
-    if pd.isna(radiation_str) or not radiation_str:
-        return ""
-    data = json.loads(radiation_str)
-    # Format acutel PP
-    if "dateCessationActivitePP" in data:
-        return parse_date_bodacc(data["dateCessationActivitePP"])
-    # Format obsolète PP
-    if "radiationPP" in data and isinstance(data["radiationPP"], dict):
-        return parse_date_bodacc(data["radiationPP"].get("dateCessationActivitePP", ""))
-    # Les PM n'ont pas de date de disponible
-    return ""
-
-
-def parse_jugement_json(jugement_str: str) -> dict:
-    """Parse le champ json jugement et en extraire famille, nature, complementJugement et date."""
-    if pd.isna(jugement_str) or not jugement_str:
-        return {"famille": "", "nature": "", "complementJugement": "", "date": ""}
-    try:
-        data = json.loads(jugement_str)
-        return {
-            "famille": fix_mojibake(data.get("famille", "")),
-            "nature": fix_mojibake(data.get("nature", "")),
-            "complementJugement": fix_mojibake(data.get("complementJugement", "")),
-            "date": parse_date_bodacc(data.get("date", "")),
-        }
-    except json.JSONDecodeError:
-        return {"famille": "", "nature": "", "complementJugement": "", "date": ""}
-
-
-def is_procedure_en_cours(nature: str) -> bool:
-    """Vérifie si la nature de jugement correspond à une procédure en cours."""
-    NATURES_CLOTURE = [
-        "clôture",
-        "cloture",
-        "clotûre",
-        "plan arrêté",
-        "plan arrete",
-        "arrêtant le plan",
-        "arretant le plan",
-    ]
-    if pd.isna(nature) or not nature:
-        return False
-    nature_lower = nature.lower()
-    return not any(kw in nature_lower for kw in NATURES_CLOTURE)
-
-
-def is_cloture(famille: str) -> bool:
-    """Vérifie si la famille correspond à une clôture de procédure."""
-    FAMILLES_CLOTURE = [
-        "jugement de clôture",
-    ]
-    if pd.isna(famille) or not famille:
-        return False
-    famille_lower = famille.lower()
-    return any(kw in famille_lower for kw in FAMILLES_CLOTURE)
-
-
-def is_retractation(famille: str) -> bool:
+def _is_jugement_retractation(famille: str) -> bool:
     """Vérifie si la famille correspond à une rétractation (équivalent annulation)."""
     # Familles équivalentes à une annulation
     FAMILLES_ANNULATION = [
@@ -149,7 +87,7 @@ def is_retractation(famille: str) -> bool:
     return any(kw in famille_lower for kw in FAMILLES_ANNULATION)
 
 
-def is_rapport_de_radiation_doffice(radiationaurcs_str: str) -> bool:
+def _is_radiationaurcs_radiation_doffice(radiationaurcs_str: str) -> bool:
     """
     Vérifie si le champ radiationaurcs indique un rapport de radiation d'office.
     Un rapport de radiation d'office correspond à l'annulation d'une radiation.
@@ -210,7 +148,7 @@ def get_previous_ids_to_discard(df: pd.DataFrame) -> set:
                 parse_json_safe(x).get("famille", "") if parse_json_safe(x) else ""
             )
         )
-        retractations = df[familles.apply(is_retractation)]
+        retractations = df[familles.apply(_is_jugement_retractation)]
         if not retractations.empty:
             ids_from_retractations = retractations["parutionavisprecedent"].apply(
                 extract_id_from_avis_precedent
@@ -236,7 +174,9 @@ def get_processed_ids_to_discard(df: pd.DataFrame) -> set:
     # Rectificatifs de type "radiation d'office" (équivalent annulation)
     if "radiationaurcs" in df.columns:
         is_rectificatif = df["typeavis"] == "rectificatif"
-        is_rad_doffice = df["radiationaurcs"].apply(is_rapport_de_radiation_doffice)
+        is_rad_doffice = df["radiationaurcs"].apply(
+            _is_radiationaurcs_radiation_doffice
+        )
         ids_to_discard.update(df.loc[is_rectificatif & is_rad_doffice, "id"].dropna())
 
     # Rétractations sur tierce opposition
@@ -247,7 +187,7 @@ def get_processed_ids_to_discard(df: pd.DataFrame) -> set:
                 parse_json_safe(x).get("famille", "") if parse_json_safe(x) else ""
             )
         )
-        retractations = df[familles.apply(is_retractation)]
+        retractations = df[familles.apply(_is_jugement_retractation)]
         ids_to_discard.update(retractations["id"].dropna())
 
     return ids_to_discard
@@ -274,7 +214,7 @@ def process_discarded_announcements(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def extract_sirens_from_personne(listepersonnes: str) -> list[str]:
+def _extract_sirens_from_personne(listepersonnes: str) -> list[str]:
     """
     Extract all unique siren from the listepersonnes field.
     If there is multiple entries, "listepersonnes" looks like:
@@ -333,41 +273,8 @@ def extract_sirens_from_listepersonnes(df: pd.DataFrame) -> pd.DataFrame:
     All columns keep the same values, only the siren one changes.
     """
     df = df.copy()
-    df["_sirens"] = df["listepersonnes"].apply(extract_sirens_from_personne)
+    df["_sirens"] = df["listepersonnes"].apply(_extract_sirens_from_personne)
     df = df[df["_sirens"].apply(len) > 0]
     df = df.explode("_sirens", ignore_index=True)
     df = df.rename(columns={"_sirens": "siren"})
     return df
-
-
-RULES_PATH = Path(__file__).parent / "rule.yml"
-
-
-def load_procedure_collective_rules() -> list[dict]:
-    with open(RULES_PATH, encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    return data["procedure_collective_rules"]
-
-
-def apply_procedure_collective_rules(
-    nature: str, complement_jugement: str, rules: list[dict]
-) -> str | None:
-    """
-    Applique les règles dans l'ordre. Retourne le statut de la première règle
-    qui matche, ou None si aucune règle ne correspond (avec un warning loggé).
-    """
-    if not nature:
-        return None
-
-    for rule in rules:
-        if rule["nature"] != nature:
-            continue
-        if "complement_contains" in rule and (
-            not complement_jugement
-            or rule["complement_contains"].lower() not in complement_jugement.lower()
-        ):
-            continue
-        return rule.get("statut")
-
-    logger.warning(f"BODACC: nature non traitée dans rule.yml : '{nature}'")
-    return None

--- a/workflows/data_pipelines/elasticsearch/data_enrichment.py
+++ b/workflows/data_pipelines/elasticsearch/data_enrichment.py
@@ -514,6 +514,15 @@ def format_dirigeants_pm(list_dirigeants_pm_sqlite, list_all_dirigeants=None):
     return dirigeants_pm_processed, list(set(list_all_dirigeants))
 
 
+def format_bodacc(bodacc_sqlite):
+    bodacc = json.loads(bodacc_sqlite) if bodacc_sqlite else {}
+    if bodacc.get("radiation"):
+        bodacc["radiation"]["est_radie"] = sqlite_str_to_bool(
+            bodacc["radiation"].get("est_radie", None)
+        )
+    return bodacc
+
+
 # Élus
 def create_list_names_elus(list_elus):
     list_elus_names = []

--- a/workflows/data_pipelines/elasticsearch/process_unites_legales.py
+++ b/workflows/data_pipelines/elasticsearch/process_unites_legales.py
@@ -9,6 +9,7 @@ from data_pipelines_annuaire.helpers.utils import (
 from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.data_enrichment import (
     calculate_company_size_factor,
     create_list_names_elus,
+    format_bodacc,
     format_dirigeants_pm,
     format_etablissements_and_complements,
     format_nom_complet,
@@ -294,29 +295,7 @@ def process_unites_legales(chunk_unites_legales_sqlite):
         )
 
         # BODACC (procédures collectives et radiations)
-        bodacc = unite_legale.get("bodacc")
-        if bodacc:
-            bodacc_data = json.loads(bodacc)
-            est_radie = sqlite_str_to_bool(bodacc_data.get("radiation_est_radie", 0))
-            procedure_colletive_statut = bodacc_data.get("procedure_collective_statut")
-            unite_legale_processed["bodacc"] = {
-                "radiation": {
-                    "est_radie": est_radie,
-                    "id_annonce": bodacc_data.get("radiation_id_annonce"),
-                    "date": bodacc_data.get("radiation_date"),
-                }
-                if est_radie
-                else None,
-                "procedure_collective": {
-                    "statut": procedure_colletive_statut,
-                    "id_annonce": bodacc_data.get("procedure_collective_id_annonce"),
-                    "date": bodacc_data.get("procedure_collective_date"),
-                }
-                if procedure_colletive_statut
-                else None,
-            }
-        else:
-            unite_legale_processed["bodacc"] = {}
+        unite_legale_processed["bodacc"] = format_bodacc(unite_legale.get("bodacc"))
 
         # TVA
         unite_legale_processed["liste_tva"] = str_to_list(

--- a/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
+++ b/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
@@ -472,15 +472,28 @@ select_fields_to_index_query = """SELECT
             ) as immatriculation,
             (
                 SELECT json_object(
-                    'radiation_est_radie', case when radiation_visibility then radiation_est_radie end,
-                    'radiation_id_annonce', case when radiation_visibility then radiation_id_annonce end,
-                    'radiation_date', case when radiation_visibility then radiation_date end,
-                    'procedure_collective_id_annonce', procedure_collective_id_annonce,
-                    'procedure_collective_statut', procedure_collective_statut,
-                    'procedure_collective_date', procedure_collective_date
+                    'radiation',
+                        (
+                            SELECT case when r.visibility then
+                                json_object(
+                                    'est_radie', r.est_radie,
+                                    'id_annonce', r.id_annonce,
+                                    'date', r.date
+                                ) end
+                            FROM bodacc_radiations AS r
+                            WHERE r.siren = ul.siren
+                        ),
+                    'procedure_collective',
+                        (
+                            SELECT json_object(
+                                'statut', pc.statut,
+                                'id_annonce', pc.id_annonce,
+                                'date', pc.date
+                            )
+                            FROM bodacc_procedures_collectives AS pc
+                            WHERE pc.siren = ul.siren
+                            )
                 )
-                FROM bodacc
-                WHERE siren = ul.siren
             ) as bodacc
             FROM
                 unite_legale ul

--- a/workflows/data_pipelines/etl/dag.py
+++ b/workflows/data_pipelines/etl/dag.py
@@ -40,7 +40,8 @@ from data_pipelines_annuaire.workflows.data_pipelines.bilans_financiers.config i
     BILANS_FINANCIERS_CONFIG,
 )
 from data_pipelines_annuaire.workflows.data_pipelines.bodacc.config import (
-    BODACC_CONFIG,
+    PROCEDURES_COLLECTIVES_CONFIG,
+    RADIATIONS_CONFIG,
 )
 from data_pipelines_annuaire.workflows.data_pipelines.colter.config import (
     COLTER_CONFIG,
@@ -221,7 +222,8 @@ def database_constructor():
             ALIM_CONFIANCE_CONFIG,
             BILAN_GES_CONFIG,
             AIDES_MINIMIS_CONFIG,
-            BODACC_CONFIG,
+            RADIATIONS_CONFIG,
+            PROCEDURES_COLLECTIVES_CONFIG,
             AIDES_ADEME_CONFIG,
             AVOCAT_CONFIG,
             TVA_CONFIG,

--- a/workflows/data_pipelines/export_bodacc_radiations/queries.py
+++ b/workflows/data_pipelines/export_bodacc_radiations/queries.py
@@ -4,41 +4,41 @@
 #   - si aucun de ses établissements n'a été créé après la date de radiation
 RADIATIONS_PP_QUERY = """
     SELECT
-        b.siren,
+        r.siren,
         ul.nom_raison_sociale AS sirene_raison_sociale,
         ul.nom AS sirene_nom,
         ul.prenom AS sirene_prenom,
-        b.radiation_date AS bodacc_radiation_date,
-        b.radiation_date_publication AS bodacc_radiation_date_publication,
-        b.radiation_id_annonce AS bodacc_radiation_id_annonce,
-        'https://www.bodacc.fr/pages/annonces-commerciales-detail/?q.id=id:' || b.radiation_id_annonce AS bodacc_annonce_url
-    FROM bodacc AS b
-    INNER JOIN unite_legale AS ul ON ul.siren = b.siren
-    WHERE b.radiation_est_radie = 1
+        r.date AS bodacc_radiation_date,
+        r.date_publication AS bodacc_radiation_date_publication,
+        r.id_annonce AS bodacc_radiation_id_annonce,
+        'https://www.bodacc.fr/pages/annonces-commerciales-detail/?q.id=id:' || r.id_annonce AS bodacc_annonce_url
+    FROM bodacc_radiations AS r
+    INNER JOIN unite_legale AS ul ON ul.siren = r.siren
+    WHERE r.est_radie = 1
       AND (
         ul.nature_juridique_unite_legale = '1000'
         OR ul.nature_juridique_unite_legale LIKE '2%'
         )
-      and b.radiation_visibility_reason = 'ei_active_on_sirene'
-    ORDER BY b.radiation_date_publication DESC
+      and r.visibility_reason = 'ei_active_on_sirene'
+    ORDER BY r.date_publication DESC
 """
 
 # Personnes morales radiées au RCS d'après le BODACC où
 # mais dont la radiation n'est pas reflétée dans SIRENE
 RADIATIONS_PM_QUERY = """
     SELECT
-        b.siren,
+        r.siren,
         ul.nom_raison_sociale AS sirene_raison_sociale,
         ul.nature_juridique_unite_legale AS sirene_nature_juridique,
-        b.radiation_date AS bodacc_radiation_date,
-        b.radiation_date_publication AS bodacc_radiation_date_publication,
-        b.radiation_id_annonce AS bodacc_radiation_id_annonce,
-        'https://www.bodacc.fr/pages/annonces-commerciales-detail/?q.id=id:' || b.radiation_id_annonce AS bodacc_annonce_url
-    FROM bodacc AS b
-    INNER JOIN unite_legale AS ul ON ul.siren = b.siren
-    WHERE b.radiation_est_radie = 1
+        r.date AS bodacc_radiation_date,
+        r.date_publication AS bodacc_radiation_date_publication,
+        r.id_annonce AS bodacc_radiation_id_annonce,
+        'https://www.bodacc.fr/pages/annonces-commerciales-detail/?q.id=id:' || r.id_annonce AS bodacc_annonce_url
+    FROM bodacc_radiations AS r
+    INNER JOIN unite_legale AS ul ON ul.siren = r.siren
+    WHERE r.est_radie = 1
         AND ul.nature_juridique_unite_legale != '1000'
         AND ul.nature_juridique_unite_legale NOT LIKE '2%'
         AND ul.etat_administratif_unite_legale = 'A'
-    ORDER BY b.siren
+    ORDER BY r.siren
 """


### PR DESCRIPTION
Refactor BODACC DAG:
* split radiations and procédures collectives to separate files 
* split those into difference Airflow tasks
* split those into two difference sqlite tables
* make the bodacc indexation query and python formatting simpler

It will improve observability and maintenance.

Tested on dev-01 ✅ 