### PR TITLE
fix(rne): uncorrelated subquery causing identical date màj rne across all rows

### DIFF
--- a/workflows/data_pipelines/etl/sqlite/queries/unite_legale.py
+++ b/workflows/data_pipelines/etl/sqlite/queries/unite_legale.py
@@ -136,9 +136,9 @@ update_main_table_fields_with_rne_data_query = """
             UPDATE unite_legale
             SET from_rne = TRUE,
                 date_mise_a_jour_rne = (
-                    SELECT date_mise_a_jour
-                    FROM db_rne.unite_legale
-                    WHERE unite_legale.siren = db_rne.unite_legale.siren
+                    SELECT MAX(r.date_mise_a_jour)
+                    FROM db_rne.unite_legale r
+                    WHERE unite_legale.siren = r.siren
                     )
             WHERE siren IN (SELECT siren FROM db_rne.unite_legale)
         """


### PR DESCRIPTION
closes https://github.com/annuaire-entreprises-data-gouv-fr/search-infra/issues/869
### Fix:
Alias the attached table explicitly (r) inside the subquery so siren correlation unambiguously references the outer UPDATE target. Also wrapped the selected column in MAX() to guard against db_rne.unite_legale containing multiple historical rows per siren, ensuring the most recent date_mise_a_jour is used rather than an arbitrary one among duplicates.
