### PR TITLE
fix(metadata.cc): new url

### DIFF
--- a/config.py
+++ b/config.py
@@ -160,12 +160,6 @@ ELASTIC_DOWNSTREAM_PASSWORD = Variable.get("ELASTIC_DOWNSTREAM_PASSWORD", "")
 API_URL = Variable.get("API_URL", "")
 API_IS_REMOTE = Variable.get("API_IS_REMOTE", "False").lower() not in ["false", "0"]
 
-# Datasets
-URL_CC_DARES = "https://travail-emploi.gouv.fr/sites/travail-emploi/files"
-# Caution: DARES file is case sensitive or returns 404
-FILE_CC_DATE = "Dares_donnes_Identifiant_convention_collective_"
-URL_CC_KALI = "https://www.data.gouv.fr/datasets/r/02b67492-5243-44e8-8dd1-0cb3f90f35ff"
-
 # DataGouv
 DATAGOUV_URL = "https://www.data.gouv.fr"
 DATAGOUV_RESOURCE_PATH = "/datasets/r/"

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -582,13 +582,19 @@ def load_file(file_name: str):
     return file_decoded
 
 
-def fetch_hyperlink_from_page(url: str, search_text: str) -> str:
+def fetch_hyperlink_from_page(
+    url: str, search_text: str, match_on: Literal["text", "href"] = "text"
+) -> str:
     """
     Fetches a URL from a web page that matches the given search text.
 
     Args:
         url (str): The URL of the web page to search.
-        search_text (str): The text to search for within the web page's HTML content.
+        search_text (str): The text to search for within the web page's HTML content:
+            either the exact content of a link or a substring of its href,
+            depending on match_on.
+        match_on (Literal["text", "href"]): Whether to match search_text against
+            the link's content or its href. Defaults to "text".
     Returns:
         str: The full URL found in the web page that matches the search text.
     Raises:
@@ -597,17 +603,18 @@ def fetch_hyperlink_from_page(url: str, search_text: str) -> str:
     """
 
     parsed_url = urlparse(url)
-    base_url = base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
 
     response = requests.get(url)
     response.raise_for_status()
     html_content = response.text
 
     logging.info(f"Looking for the URL behind: {search_text}")
-    match = re.search(
-        r'<a\s+[^>]*href="([^"]+)"[^>]*>' + re.escape(search_text) + r"</a>",
-        html_content,
-    )
+    if match_on == "href":
+        pattern = r'<a\s+[^>]*href="([^"]*' + re.escape(search_text) + r'[^"]*)"'
+    else:
+        pattern = r'<a\s+[^>]*href="([^"]+)"[^>]*>' + re.escape(search_text) + r"</a>"
+    match = re.search(pattern, html_content)
 
     if not match:
         raise ValueError(f"No URL found in the html source of: {url}")

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -1,8 +1,11 @@
 import logging
 import os
 import tempfile
+from unittest.mock import MagicMock, patch
 
 import pytest
+
+from data_pipelines_annuaire.helpers.utils import fetch_hyperlink_from_page
 
 
 def get_last_line(file_path):
@@ -86,3 +89,47 @@ def test_error_reading_last_line(temp_file_path):
     os.chmod(temp_file_path, 0o000)
     result = get_last_line(temp_file_path)
     assert result is None
+
+
+PAGE_HTML = """
+<a href="/documents/report.pdf" class="link">Annual report</a>
+<a href="/files/2026-06/Monthly_Data_Export_June2026.xlsx"
+   type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+   class="link link--download" download>     Monthly data
+   export <span class="link__detail">(XLSX - 188.18 Ko)</span>
+</a>
+"""
+
+
+@pytest.fixture
+def mock_page_response():
+    with patch("data_pipelines_annuaire.helpers.utils.requests.get") as mock_get:
+        mock_get.return_value = MagicMock(text=PAGE_HTML)
+        yield mock_get
+
+
+def test_fetch_hyperlink_matching_text(mock_page_response):
+    result = fetch_hyperlink_from_page("https://example.com/some-page", "Annual report")
+    assert result == "https://example.com/documents/report.pdf"
+
+
+def test_fetch_hyperlink_matching_href(mock_page_response):
+    # The anchor content is spread over several lines and contains a nested
+    # span, so only an href match can find it
+    result = fetch_hyperlink_from_page(
+        "https://example.com/some-page",
+        "Monthly_Data_Export_",
+        match_on="href",
+    )
+    assert (
+        result == "https://example.com/files/2026-06/Monthly_Data_Export_June2026.xlsx"
+    )
+
+
+def test_fetch_hyperlink_not_found(mock_page_response):
+    with pytest.raises(ValueError):
+        fetch_hyperlink_from_page(
+            "https://example.com/some-page",
+            "not_in_the_page",
+            match_on="href",
+        )

--- a/workflows/data_pipelines/metadata/cc/README.md
+++ b/workflows/data_pipelines/metadata/cc/README.md
@@ -6,6 +6,6 @@
 | -------- | -------- |
 | Fichier source | `dag.py` |
 | Description | Ce traitement permet de récupérer les metadonnées sur les conventions collectives. |
-| Fréquence | Tous les 3 jours entre le 2 et le 31 du mois. Cependant la mise à jour des metadonnées est désactivées dans le cas où un fichier a déjà été téléversé sur le mois. |
+| Fréquence | À 11h les 2 et 16 du mois. Cependant la mise à jour des metadonnées est désactivées dans le cas où un fichier a déjà été téléversé sur le mois. |
 | Données sources | [Liste des conventions collectives et de leur code](https://travail-emploi.gouv.fr/conventions-collectives-nomenclatures) |
 | Données de sorties | Object Storage |

--- a/workflows/data_pipelines/metadata/cc/dag.py
+++ b/workflows/data_pipelines/metadata/cc/dag.py
@@ -22,7 +22,7 @@ default_args = {
 @dag(
     default_args=default_args,
     start_date=datetime(2026, 1, 1),
-    schedule="0 11 2,3 * *",  # At 11:00 on the 2nd and 3rd day of every month
+    schedule="0 11 2,16 * *",  # At 11:00 on the 2nd and 16th day of every month
     catchup=False,
     max_active_runs=1,
     dagrun_timeout=timedelta(minutes=(60 * 100)),

--- a/workflows/data_pipelines/metadata/cc/task_functions.py
+++ b/workflows/data_pipelines/metadata/cc/task_functions.py
@@ -8,42 +8,18 @@ from airflow.sdk import get_current_context
 from requests.exceptions import HTTPError
 
 from data_pipelines_annuaire.config import (
-    FILE_CC_DATE,
     METADATA_CC_OBJECT_STORAGE_PATH,
     METADATA_CC_TMP_FOLDER,
-    URL_CC_DARES,
-    URL_CC_KALI,
 )
 from data_pipelines_annuaire.helpers.notification import Notification
 from data_pipelines_annuaire.helpers.object_storage import File, ObjectStorageClient
-from data_pipelines_annuaire.helpers.utils import get_previous_months
+from data_pipelines_annuaire.helpers.utils import fetch_hyperlink_from_page
 
-
-def get_month_year_french():
-    # Mapping of month numbers to French month names in lowercase
-    month_mapping = {
-        1: "janvier",
-        2: "février",
-        3: "mars",
-        4: "avril",
-        5: "mai",
-        6: "juin",
-        7: "juillet",
-        8: "aout",
-        9: "septembre",
-        10: "octobre",
-        11: "novembre",
-        12: "décembre",
-    }
-
-    current_date = datetime.now()
-    month_number = current_date.month
-    month_name_french = month_mapping.get(month_number, "unknown").title()
-
-    year_last_two_digits = str(current_date.year)[-2:]
-    # Format the result as 'monthYear'
-    result = f"{month_name_french}{year_last_two_digits}"
-    return result
+# Datasets
+URL_CC_DARES = "https://travail-emploi.gouv.fr/conventions-collectives-nomenclatures"
+URL_CC_KALI = "https://www.data.gouv.fr/datasets/r/02b67492-5243-44e8-8dd1-0cb3f90f35ff"
+# Stable prefix of the DARES file name, used to find its download link on the page
+FILE_CC_DATE = "Dares_Suivi_Historique_convention_collective_"
 
 
 def is_metadata_not_updated() -> bool:
@@ -66,30 +42,34 @@ def is_metadata_not_updated() -> bool:
 
 
 def create_metadata_convention_collective_json():
-    current_cc_dares_file = f"{FILE_CC_DATE}{get_month_year_french()}.xlsx"
-    months = get_previous_months(lookback=3)
-    logging.info(months)
-    # We try to fetch the file from previous folder months because sometimes
-    # the file is not uploaded to the right folder
-    for month in months:
-        current_url_cc_dares = f"{URL_CC_DARES}/{month}/{current_cc_dares_file}"
-        logging.info(f"CC Dares URL: {current_url_cc_dares}")
-
+    # The file name and its remote folder change every few month and are not always
+    # consistent so we parse the downloadable link from the page instead of
+    # guessing the URL
+    file_downloaded = False
+    current_url_cc_dares = URL_CC_DARES
+    try:
+        current_url_cc_dares = fetch_hyperlink_from_page(
+            URL_CC_DARES, FILE_CC_DATE, match_on="href"
+        )
         r = requests.get(current_url_cc_dares, allow_redirects=True)
-        if r.ok:
-            break
+        # travail-emploi.gouv.fr sometimes answers 200 with an HTML page
+        # instead of the file, so r.ok is not enough: check the xlsx zip
+        # signature to be sure we actually downloaded a spreadsheet
+        file_downloaded = r.ok and r.content[:4] == b"PK\x03\x04"
+    except (ValueError, requests.exceptions.RequestException) as e:
+        logging.warning(f"Failed to fetch the CC Dares file: {e}")
 
-    if not r.ok:
-        # The file is often unavailable, this is expected but
+    if not file_downloaded:
+        # The file is sometimes unavailable, this is expected but
         # we need to be informed to act upon it if it has been too long
         last_run_date = ObjectStorageClient().get_date_last_modified(
             f"{METADATA_CC_OBJECT_STORAGE_PATH}cc_kali.json"
         )
         if last_run_date is not None:
             date_diff = datetime.now() - datetime.fromisoformat(last_run_date)
-            error_message = f"\u26a0\ufe0f {r.status_code}: Le fichier CC du DARES n'est pas disponible depuis {date_diff.days} jours."
+            error_message = f"\u26a0\ufe0f Le fichier CC du DARES n'est pas disponible depuis {date_diff.days} jours."
         else:
-            error_message = f"\u26a0\ufe0f {r.status_code}: Le fichier CC du DARES n'est pas disponible."
+            error_message = "\u26a0\ufe0f Le fichier CC du DARES n'est pas disponible."
         logging.warning(error_message)
         ti = get_current_context()["ti"]
         ti.xcom_push(key=Notification.notification_xcom_key, value=error_message)
@@ -100,11 +80,15 @@ def create_metadata_convention_collective_json():
             f.write(chunk)
     df_dares = pd.read_excel(
         METADATA_CC_TMP_FOLDER + "dares-download.xlsx",
+        sheet_name="Conventions de branche",
         dtype=str,
         header=0,
-        skiprows=3,
         engine="openpyxl",
     )
+    # DARES pads IDCC to 5 digits (e.g. 00176) while Kali doesn't (e.g. 176)
+    # We have to strip leading zeros so both dataframes can be merged
+    df_dares["IDCC"] = df_dares["IDCC"].str.lstrip("0")
+    df_dares = df_dares.rename(columns={"Libellé": "titre de la convention"})
     # Get Kali list
     r = requests.get(URL_CC_KALI, allow_redirects=True)
     with open(METADATA_CC_TMP_FOLDER + "kali-download.xlsx", "wb") as f:


### PR DESCRIPTION
The CC metadata file has a new name and new format.
The code to fetch the .xslx file has been simplified by reusing the existing `fetch_hyperlink_from_page()` function instead of guessing the file name, which happened to be quite inconsistent.