### PR TITLE
fix(sirene.flux): use timezone for schedule

### DIFF
--- a/workflows/data_pipelines/sirene/flux/dag.py
+++ b/workflows/data_pipelines/sirene/flux/dag.py
@@ -1,5 +1,6 @@
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 
+import pendulum
 from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.sdk import dag, task
@@ -22,8 +23,8 @@ default_args = {
 @dag(
     tags=["sirene", "flux"],
     default_args=default_args,
-    schedule="30 6 * * *",  # Daily at 6:30 AM
-    start_date=datetime(2026, 1, 1, tzinfo=UTC),
+    schedule="30 7 * * *",  # Daily at 7:30 AM Paris timezone
+    start_date=pendulum.datetime(2026, 1, 1, tz="Europe/Paris"),
     dagrun_timeout=timedelta(minutes=60 * 12),
     params={},
     catchup=False,


### PR DESCRIPTION
```bash
[2026-08-11 08:30:01] INFO -   ✓ dateDerniereMiseADisposition = 2026-08-11T07:53:14.000 (parsed: 2026-08-11, is_today: True)
```

En heure d'été l'API différentielle SIRENE est prête avant 8h30, heure d'exécution du DAG de récupération du flux.
Utiliser le fuseau horaire français permet au DAG de s'exécuter de la même manière en hiver et en été. Cela fera gagner ~30 minutes pour la mise à jours des données de l'API en été.

https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/timezone.html#time-zone-aware-dags

J'ai testé en mettant `schedule="0 17 * * *"` et ça a bien exécuté le DAG à 17h CEST ✅ 