### PR TITLE
fix: remove content-encoding metadata for .db.gz files

### DIFF
--- a/helpers/object_storage.py
+++ b/helpers/object_storage.py
@@ -135,7 +135,7 @@ class ObjectStorageClient:
 
         object_key = f"{OBJECT_STORAGE_ENV_PATH}{object_storage_path}{dest_name}"
 
-        extra_args = {"ContentEncoding": "gzip"}
+        extra_args: dict[str, str] = {}
         if is_public:
             extra_args["ACL"] = "public-read"
         if content_type:

--- a/tests/unit_tests/test_object_storage.py
+++ b/tests/unit_tests/test_object_storage.py
@@ -142,7 +142,8 @@ def test_upload_compressed_file_roundtrips_as_gzip(tmp_path):
         captured["key"] == f"ae/{AIRFLOW_ENV}/sirene/database/sirene_2024-03-15.db.gz"
     )
     assert captured["extra_args"]["ACL"] == "public-read"
-    assert captured["extra_args"]["ContentEncoding"] == "gzip"
+    # ContentEncoding would make HTTP requests decompress the file on the fly
+    assert "ContentEncoding" not in captured["extra_args"]
 
 
 def test_upload_compressed_file_raises_when_dest_name_not_gz(tmp_path):


### PR DESCRIPTION
Lorsque j'ai intégré `pigz` j'ai ajouté une métadonnée `Content-Encoding` mais celle ci fait que les fichiers `.db.gz` sont décompressés pendant le téléchargement lorsqu'on essaie de télécharger les fichiers via CyberDuck ou via le web.
Les appels `curl` ou `python.requests` fonctionnaient toujours comme auparavant.
Or vu la taille du fichier il est plus pertinent de gérer la décompression manuellement après le téléchargement.