### PR TITLE
feat: use a custom email template for dag errors

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -2,7 +2,10 @@ from data_pipelines_annuaire.helpers.api_client import AirflowApiClient, ApiClie
 from data_pipelines_annuaire.helpers.data_processor import DataProcessor
 from data_pipelines_annuaire.helpers.data_quality import clean_sirent_column
 from data_pipelines_annuaire.helpers.filesystem import LocalFile
-from data_pipelines_annuaire.helpers.notification import Notification
+from data_pipelines_annuaire.helpers.notification import (
+    EmailNotification,
+    Notification,
+)
 from data_pipelines_annuaire.helpers.object_storage import ObjectStorageClient
 from data_pipelines_annuaire.helpers.sqlite_client import SqliteClient
 
@@ -10,6 +13,7 @@ __all__ = [
     "AirflowApiClient",
     "ApiClient",
     "DataProcessor",
+    "EmailNotification",
     "LocalFile",
     "Notification",
     "ObjectStorageClient",

--- a/helpers/notification.py
+++ b/helpers/notification.py
@@ -1,8 +1,39 @@
 from enum import Enum
+from pathlib import Path
+from zoneinfo import ZoneInfo
 
+from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import BaseNotifier
 
+from data_pipelines_annuaire.config import AIRFLOW_ENV
 from data_pipelines_annuaire.helpers import AirflowApiClient, tchap
+
+EMAIL_NOTIFICATION_TEMPLATE = (
+    Path(__file__).parent / "templates" / "email_notification.html"
+).as_posix()
+EMAIL_TIMEZONE = ZoneInfo("Europe/Paris")
+
+
+class EmailNotification(SmtpNotifier):
+    """
+    SmtpNotifier extended with a custom email template.
+
+    Usage:
+        >>> on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
+    """
+
+    template_fields = (*SmtpNotifier.template_fields, "env", "tz")
+
+    def __init__(self, to, subject=None, **kwargs):
+        kwargs.setdefault("template", EMAIL_NOTIFICATION_TEMPLATE)
+        if subject is None:
+            subject = (
+                "[Annuaire des Entreprises - {{ env }}] "
+                "🔴 Échec du DAG {{ dag.dag_id }}"
+            )
+        self.env = AIRFLOW_ENV
+        self.tz = EMAIL_TIMEZONE
+        super().__init__(to=to, subject=subject, **kwargs)
 
 
 class Notification(BaseNotifier):
@@ -19,13 +50,13 @@ class Notification(BaseNotifier):
 
     Usage:
         Add the following parameters to a DAG definition:
-            >> on_failure_callback=Notification(),
-            >> on_success_callback=Notification(),
+            >>> on_failure_callback=Notification(),
+            >>> on_success_callback=Notification(),
 
         [Optional] In the relevant @task, use the following code to provide additional
         context for the notification:
-            >> from data_pipelines_annuaire.helpers import Notification
-            >> ti.xcom_push(key=Notification.notification_xcom_key, value=error_message)
+            >>> from data_pipelines_annuaire.helpers import Notification
+            >>> ti.xcom_push(key=Notification.notification_xcom_key, value=error_message)
     """
 
     notification_xcom_key = "notification_message"

--- a/helpers/templates/README.md
+++ b/helpers/templates/README.md
@@ -1,0 +1,25 @@
+# Email templates
+
+`email_notification.html` is the body sent by `EmailNotification` in `helpers/notification.py`.
+It is used on every DAG in the `on_failure_callback` setting.
+
+## Variables
+
+| Variable                                           | Source |
+| -------------------------------------------------- | ----------------------------------------------------------- |
+| `env`                                              | `AIRFLOW_ENV` dans `config.py` |
+| `tz`                                               | `EMAIL_TIMEZONE` (`Europe/Paris`) dans `notification.py` |
+| `dag.dag_id`                                       | the failing DAG name |
+| `reason`                                           | the failure message |
+| `dag_run.state`, `.run_id`, `.run_type`            | DAG information |
+| `dag_run.logical_date`, `.start_date`, `.end_date` | datetimes of DAG run |
+| `ti.log_url`                                       | link to the task log |
+| `ti.task_id`, `ti.try_number`, `.max_tries`        | task information |
+
+## Warning
+
+- The DAG Jinja env uses `StrictUndefined`, so calling a variable not set will raise an error when
+  sending the email time. `x is defined` checks are required.
+- `SmtpNotifier._read_template` removes every `\n` from the template before rendering.
+  So we need to keep each Jinja expression in a single line and use `<!-- prettier-ignore -->`
+  to avoid formatters adding new lines.

--- a/helpers/templates/email_notification.html
+++ b/helpers/templates/email_notification.html
@@ -1,0 +1,576 @@
+<!doctype html>
+<html lang="fr">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="color-scheme" content="light" />
+        <meta name="supported-color-schemes" content="light" />
+        <title>Annuaire des Entreprises — Notification Airflow</title>
+    </head>
+    <body
+        style="
+            margin: 0;
+            padding: 0;
+            background-color: #eeeeee;
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        "
+    >
+        <!-- Preheader (hidden) -->
+        <div
+            style="
+                display: none;
+                max-height: 0;
+                overflow: hidden;
+                opacity: 0;
+                color: #eeeeee;
+                font-size: 1px;
+                line-height: 1px;
+            "
+        >
+            Échec du DAG {{ dag.dag_id }} — pipeline de données de l'Annuaire
+            des Entreprises.
+        </div>
+
+        <table
+            role="presentation"
+            width="100%"
+            cellpadding="0"
+            cellspacing="0"
+            border="0"
+            style="background-color: #eeeeee"
+        >
+            <tr>
+                <td align="center" style="padding: 24px 12px">
+                    <table
+                        role="presentation"
+                        width="600"
+                        cellpadding="0"
+                        cellspacing="0"
+                        border="0"
+                        style="
+                            width: 600px;
+                            max-width: 600px;
+                            background-color: #ffffff;
+                            border: 1px solid #dddddd;
+                        "
+                    >
+                        <!-- ===== Product name ===== -->
+                        <tr>
+                            <td style="padding: 24px 32px 4px 32px">
+                                <div
+                                    style="
+                                        font-family:
+                                            &quot;Marianne&quot;,
+                                            &quot;Segoe UI&quot;, Arial,
+                                            sans-serif;
+                                        font-size: 20px;
+                                        line-height: 26px;
+                                        font-weight: 700;
+                                        color: #000091;
+                                    "
+                                >
+                                    Annuaire des Entreprises
+                                </div>
+                                <div
+                                    style="
+                                        font-family:
+                                            &quot;Marianne&quot;,
+                                            &quot;Segoe UI&quot;, Arial,
+                                            sans-serif;
+                                        font-size: 13px;
+                                        line-height: 18px;
+                                        color: #666666;
+                                        padding-top: 2px;
+                                    "
+                                >
+                                    Infrastructure de données · Airflow
+                                </div>
+                                <div style="padding-top: 10px">
+                                    <!-- prettier-ignore -->
+                                    <span
+                                        style="
+                                            display: inline-block;
+                                            padding: 3px 10px;
+                                            border-radius: 4px;
+                                            background-color: #e8edff;
+                                            font-family:
+                                                &quot;Marianne&quot;,
+                                                &quot;Segoe UI&quot;, Arial,
+                                                sans-serif;
+                                            font-size: 12px;
+                                            line-height: 18px;
+                                            font-weight: 700;
+                                            letter-spacing: 0.4px;
+                                            text-transform: uppercase;
+                                            color: #000091;
+                                        "
+                                        >Environnement&nbsp;: {{ env }}</span
+                                    >
+                                </div>
+                            </td>
+                        </tr>
+
+                        <!-- ===== Alert banner ===== -->
+                        <tr>
+                            <td style="padding: 20px 32px 8px 32px">
+                                <table
+                                    role="presentation"
+                                    width="100%"
+                                    cellpadding="0"
+                                    cellspacing="0"
+                                    border="0"
+                                    style="
+                                        background-color: #fff0f0;
+                                        border-left: 4px solid #ce0500;
+                                    "
+                                >
+                                    <tr>
+                                        <td
+                                            style="
+                                                padding: 16px 20px;
+                                                font-family:
+                                                    &quot;Marianne&quot;,
+                                                    &quot;Segoe UI&quot;, Arial,
+                                                    sans-serif;
+                                            "
+                                        >
+                                            <div
+                                                style="
+                                                    font-size: 16px;
+                                                    line-height: 22px;
+                                                    font-weight: 700;
+                                                    color: #ce0500;
+                                                "
+                                            >
+                                                🔴 Échec d'un traitement de
+                                                données
+                                            </div>
+                                            <div
+                                                style="
+                                                    font-size: 14px;
+                                                    line-height: 20px;
+                                                    color: #3a3a3a;
+                                                    padding-top: 6px;
+                                                "
+                                            >
+                                                Le DAG
+                                                <strong style="color: #161616"
+                                                    >{{ dag.dag_id }}</strong
+                                                >
+                                                s'est terminé en erreur. {% if
+                                                reason is defined and reason
+                                                %}<br />Motif&nbsp;: {{ reason
+                                                }}{% endif %}
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+
+                        <!-- ===== Details card ===== -->
+                        <tr>
+                            <td style="padding: 12px 32px 8px 32px">
+                                <div
+                                    style="
+                                        font-family:
+                                            &quot;Marianne&quot;,
+                                            &quot;Segoe UI&quot;, Arial,
+                                            sans-serif;
+                                        font-size: 12px;
+                                        line-height: 16px;
+                                        font-weight: 700;
+                                        letter-spacing: 0.6px;
+                                        color: #666666;
+                                        text-transform: uppercase;
+                                        padding-bottom: 8px;
+                                    "
+                                >
+                                    Détails de l'exécution
+                                </div>
+                                <table
+                                    role="presentation"
+                                    width="100%"
+                                    cellpadding="0"
+                                    cellspacing="0"
+                                    border="0"
+                                    style="
+                                        border: 1px solid #eeeeee;
+                                        border-radius: 4px;
+                                        font-family:
+                                            &quot;Marianne&quot;,
+                                            &quot;Segoe UI&quot;, Arial,
+                                            sans-serif;
+                                    "
+                                >
+                                    <tr>
+                                        <td
+                                            width="40%"
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #666666;
+                                                background-color: #f6f6f6;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            DAG
+                                        </td>
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #161616;
+                                                font-weight: 600;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            {{ dag.dag_id }}
+                                        </td>
+                                    </tr>
+
+                                    {% if dag_run is defined and dag_run %}
+                                    <tr>
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #666666;
+                                                background-color: #f6f6f6;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            Statut
+                                        </td>
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            <span
+                                                style="
+                                                    display: inline-block;
+                                                    font-size: 12px;
+                                                    font-weight: 700;
+                                                    color: #ffffff;
+                                                    background-color: #ce0500;
+                                                    padding: 3px 10px;
+                                                    border-radius: 4px;
+                                                    text-transform: uppercase;
+                                                    letter-spacing: 0.4px;
+                                                "
+                                                >{{ dag_run.state }}</span
+                                            >
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #666666;
+                                                background-color: #f6f6f6;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            Run ID
+                                        </td>
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #161616;
+                                                border-bottom: 1px solid #eeeeee;
+                                                word-break: break-all;
+                                            "
+                                        >
+                                            {{ dag_run.run_id }}
+                                        </td>
+                                    </tr>
+                                    {% if dag_run.run_type %}
+                                    <tr>
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #666666;
+                                                background-color: #f6f6f6;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            Type de déclenchement
+                                        </td>
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #161616;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            {{ dag_run.run_type }}
+                                        </td>
+                                    </tr>
+                                    {% endif %} {% if dag_run.logical_date %}
+                                    <tr>
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #666666;
+                                                background-color: #f6f6f6;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            Date logique
+                                        </td>
+                                        <!-- prettier-ignore -->
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #161616;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            {{ dag_run.logical_date.astimezone(tz).strftime('%d/%m/%Y %H:%M %Z') }}
+                                        </td>
+                                    </tr>
+                                    {% endif %} {% if dag_run.start_date %}
+                                    <tr>
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #666666;
+                                                background-color: #f6f6f6;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            Début
+                                        </td>
+                                        <!-- prettier-ignore -->
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #161616;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            {{ dag_run.start_date.astimezone(tz).strftime('%d/%m/%Y %H:%M:%S %Z') }}
+                                        </td>
+                                    </tr>
+                                    {% endif %} {% if dag_run.end_date %}
+                                    <tr>
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #666666;
+                                                background-color: #f6f6f6;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            Fin
+                                        </td>
+                                        <!-- prettier-ignore -->
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #161616;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            {{ dag_run.end_date.astimezone(tz).strftime('%d/%m/%Y %H:%M:%S %Z') }}
+                                        </td>
+                                    </tr>
+                                    {% endif %} {% endif %} {% if ti is defined
+                                    and ti %}
+                                    <tr>
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #666666;
+                                                background-color: #f6f6f6;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            Tâche en échec
+                                        </td>
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #161616;
+                                                font-weight: 600;
+                                                border-bottom: 1px solid #eeeeee;
+                                            "
+                                        >
+                                            {{ ti.task_id }}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #666666;
+                                                background-color: #f6f6f6;
+                                            "
+                                        >
+                                            Tentative
+                                        </td>
+                                        <!-- prettier-ignore -->
+                                        <td
+                                            style="
+                                                padding: 12px 16px;
+                                                font-size: 13px;
+                                                color: #161616;
+                                            "
+                                        >
+                                            {{ ti.try_number }} sur {{ ti.max_tries + 1 }}
+                                        </td>
+                                    </tr>
+                                    {% endif %}
+                                </table>
+                            </td>
+                        </tr>
+
+                        {% if ti is defined and ti %}
+                        <!-- ===== Call to action ===== -->
+                        <tr>
+                            <td style="padding: 20px 32px 4px 32px">
+                                <table
+                                    role="presentation"
+                                    cellpadding="0"
+                                    cellspacing="0"
+                                    border="0"
+                                >
+                                    <tr>
+                                        <td
+                                            style="
+                                                background-color: #000091;
+                                                border-radius: 4px;
+                                            "
+                                        >
+                                            <a
+                                                href="{{ ti.log_url }}"
+                                                target="_blank"
+                                                style="
+                                                    display: inline-block;
+                                                    padding: 12px 24px;
+                                                    font-family:
+                                                        &quot;Marianne&quot;,
+                                                        &quot;Segoe UI&quot;,
+                                                        Arial, sans-serif;
+                                                    font-size: 14px;
+                                                    font-weight: 700;
+                                                    color: #ffffff;
+                                                    text-decoration: none;
+                                                "
+                                            >
+                                                Consulter les logs Airflow
+                                                &rarr;
+                                            </a>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                        {% endif %}
+
+                        <!-- ===== Footer ===== -->
+                        <tr>
+                            <td
+                                style="
+                                    padding: 20px 32px;
+                                    background-color: #f6f6f6;
+                                    border-top: 1px solid #eeeeee;
+                                    font-family:
+                                        &quot;Marianne&quot;,
+                                        &quot;Segoe UI&quot;, Arial, sans-serif;
+                                "
+                            >
+                                <div
+                                    style="
+                                        font-size: 13px;
+                                        line-height: 18px;
+                                        font-weight: 700;
+                                        color: #161616;
+                                    "
+                                >
+                                    Annuaire des Entreprises
+                                </div>
+                                <div
+                                    style="
+                                        font-size: 12px;
+                                        line-height: 18px;
+                                        color: #666666;
+                                        padding-top: 4px;
+                                    "
+                                >
+                                    Un service public conçu par la Direction
+                                    interministérielle du numérique (DINUM).
+                                </div>
+                                <div
+                                    style="
+                                        font-size: 12px;
+                                        line-height: 18px;
+                                        padding-top: 8px;
+                                    "
+                                >
+                                    <a
+                                        href="https://annuaire-entreprises.data.gouv.fr"
+                                        target="_blank"
+                                        style="
+                                            color: #000091;
+                                            text-decoration: underline;
+                                        "
+                                        >annuaire-entreprises.data.gouv.fr</a
+                                    >
+                                </div>
+                                <div
+                                    style="
+                                        font-size: 12px;
+                                        line-height: 18px;
+                                        color: #666666;
+                                        padding-top: 12px;
+                                    "
+                                >
+                                    Vous recevez cet e-mail mais ce n'est pas
+                                    censé être le cas&nbsp;?
+                                    <a
+                                        href="https://annuaire-entreprises.data.gouv.fr/faq/parcours"
+                                        target="_blank"
+                                        style="
+                                            color: #000091;
+                                            text-decoration: underline;
+                                        "
+                                        >Contactez l'équipe Annuaire</a
+                                    >.
+                                </div>
+                                <div
+                                    style="
+                                        font-size: 11px;
+                                        line-height: 16px;
+                                        color: #999999;
+                                        padding-top: 12px;
+                                    "
+                                >
+                                    Message automatique envoyé par le pipeline
+                                    de données. Merci de ne pas y répondre.
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </body>
+</html>

--- a/tests/unit_tests/test_notification.py
+++ b/tests/unit_tests/test_notification.py
@@ -1,0 +1,105 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from jinja2 import StrictUndefined
+from jinja2.sandbox import SandboxedEnvironment
+
+from data_pipelines_annuaire.config import AIRFLOW_ENV
+from data_pipelines_annuaire.helpers.notification import (
+    EMAIL_TIMEZONE,
+    EmailNotification,
+)
+
+
+def render(notifier, context):
+    context = {**context, "env": notifier.env, "tz": notifier.tz}
+    jinja_env = SandboxedEnvironment(undefined=StrictUndefined, cache_size=0)
+    return jinja_env.from_string(notifier.html_content).render(**context)
+
+
+@pytest.fixture
+def notifier():
+    """Holds the exact string Airflow renders, newlines stripped by SmtpNotifier."""
+    return EmailNotification(to=["ops@example.fr"])
+
+
+@pytest.fixture
+def full_context():
+    return {
+        "dag": SimpleNamespace(dag_id="data_processing_avocat"),
+        "reason": "Task download_data failed",
+        "dag_run": SimpleNamespace(
+            state="failed",
+            run_id="manual__2026-07-08T03:00:00",
+            run_type="scheduled",
+            logical_date=datetime(2026, 7, 8, 3, 0, tzinfo=UTC),
+            start_date=datetime(2026, 7, 8, 3, 0, 1, tzinfo=UTC),
+            end_date=datetime(2026, 7, 8, 3, 4, 12, tzinfo=UTC),
+        ),
+        "ti": SimpleNamespace(
+            task_id="download_data",
+            try_number=2,
+            max_tries=1,
+            log_url="https://airflow.example/log",
+        ),
+    }
+
+
+def test_template_renders_with_task_instance(notifier, full_context):
+    html = render(notifier, full_context)
+
+    assert "data_processing_avocat" in html
+    assert "download_data" in html
+    assert "2 sur 2" in html
+    assert "https://airflow.example/log" in html
+    assert "#000091" in html
+    assert "Annuaire des Entreprises" in html
+    assert f"Environnement&nbsp;: {AIRFLOW_ENV}" in html
+
+
+def test_template_renders_without_task_instance(notifier, full_context):
+    """DAG-level failure callbacks may not include a task instance."""
+    context = {k: v for k, v in full_context.items() if k != "ti"}
+
+    html = render(notifier, context)
+
+    assert "data_processing_avocat" in html
+    # Task-only sections are omitted, no dangling template errors
+    assert "Consulter les logs" not in html
+    assert "Tentative" not in html
+
+
+def test_email_notification_defaults(notifier):
+    assert notifier.html_content is not None
+    assert "Annuaire des Entreprises" in notifier.html_content
+    assert "{{ dag.dag_id }}" in notifier.subject
+    assert "{{ env }}" in notifier.subject
+
+
+def test_env_is_exposed_to_the_template(notifier):
+    """Airflow ENV must be a template field."""
+    assert notifier.env == AIRFLOW_ENV
+    assert "env" in notifier.template_fields
+
+
+def test_tz_is_exposed_to_the_template(notifier):
+    """Europe/Paris must be a template field."""
+    assert notifier.tz == EMAIL_TIMEZONE
+    assert "tz" in notifier.template_fields
+
+
+def test_dates_render_in_paris_time(notifier, full_context):
+    """Airflow stores UTC, the email shows Europe/Paris (UTC+2 in July)."""
+    html = render(notifier, full_context)
+
+    assert "08/07/2026 05:00 CEST" in html
+    assert "08/07/2026 05:00:01 CEST" in html
+    assert "08/07/2026 05:04:12 CEST" in html
+
+
+def test_email_notification_subject_override():
+    notifier = EmailNotification(to="ops@example.fr", subject="custom subject")
+
+    assert notifier.subject == "custom subject"
+    assert notifier.html_content is not None

--- a/workflows/data_pipelines/achats_responsables/dag.py
+++ b/workflows/data_pipelines/achats_responsables/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.achats_responsables.processor import (
     AchatsResponsablesProcessor,
 )
@@ -23,7 +22,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/agence_bio/dag.py
+++ b/workflows/data_pipelines/agence_bio/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.agence_bio.processor import (
     AgenceBioProcessor,
 )
@@ -23,7 +22,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/aides_ademe/dag.py
+++ b/workflows/data_pipelines/aides_ademe/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.aides_ademe.processor import (
     AidesAdemeProcessor,
 )
@@ -23,7 +22,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/aides_minimis/dag.py
+++ b/workflows/data_pipelines/aides_minimis/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.aides_minimis.processor import (
     AidesMinimisProcessor,
 )
@@ -23,7 +22,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/alim_confiance/dag.py
+++ b/workflows/data_pipelines/alim_confiance/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.alim_confiance.processor import (
     AlimConfianceProcessor,
 )
@@ -23,7 +22,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/avocat/dag.py
+++ b/workflows/data_pipelines/avocat/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.avocat.config import AVOCAT_CONFIG
 from data_pipelines_annuaire.workflows.data_pipelines.avocat.processor import (
     AvocatProcessor,
@@ -24,7 +23,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/bilan_ges/dag.py
+++ b/workflows/data_pipelines/bilan_ges/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.bilan_ges.config import (
     BILAN_GES_CONFIG,
 )
@@ -28,7 +27,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/bilans_financiers/dag.py
+++ b/workflows/data_pipelines/bilans_financiers/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.bilans_financiers.processor import (
     BilansFinanciersProcessor,
 )
@@ -23,7 +22,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60 * 2),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/bodacc/dag.py
+++ b/workflows/data_pipelines/bodacc/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.bodacc.processor import (
     BodaccProcessor,
 )
@@ -23,7 +22,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
 )
 def data_processing_bodacc():

--- a/workflows/data_pipelines/colter/dag.py
+++ b/workflows/data_pipelines/colter/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import Asset, dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.colter.config import (
     COLTER_CONFIG,
     ELUS_CONFIG,
@@ -28,7 +27,7 @@ dataset_colter = Asset(COLTER_CONFIG.name)
     schedule="0 16 * * *",
     start_date=datetime(2026, 1, 1, tzinfo=UTC),
     dagrun_timeout=timedelta(minutes=60),
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
     params={},
@@ -84,7 +83,7 @@ def data_processing_collectivite_territoriale():
     schedule=[dataset_colter],
     start_date=datetime(2026, 1, 1, tzinfo=UTC),
     dagrun_timeout=timedelta(minutes=60),
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     params={},
     catchup=False,

--- a/workflows/data_pipelines/convcollective/dag.py
+++ b/workflows/data_pipelines/convcollective/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.convcollective.processor import (
     ConventionCollectiveProcessor,
 )
@@ -23,7 +22,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/data_gouv/dag.py
+++ b/workflows/data_pipelines/data_gouv/dag.py
@@ -1,13 +1,12 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, setup, task, teardown
 
 from data_pipelines_annuaire.config import (
     AIRFLOW_DAG_TMP,
     EMAIL_LIST,
 )
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.helpers.datagouv import (
     post_resource,
     update_dataset_description,
@@ -32,7 +31,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60 * 3),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/egapro/dag.py
+++ b/workflows/data_pipelines/egapro/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.egapro.config import EGAPRO_CONFIG
 from data_pipelines_annuaire.workflows.data_pipelines.egapro.processor import (
     EgaproProcessor,
@@ -26,7 +25,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/elasticsearch/dag_index_data.py
+++ b/workflows/data_pipelines/elasticsearch/dag_index_data.py
@@ -2,7 +2,6 @@ import os
 import shutil
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.sdk import dag, task
 
@@ -21,7 +20,11 @@ from data_pipelines_annuaire.config import (
     REDIS_PORT,
     SIRENE_OBJECT_STORAGE_DATA_PATH,
 )
-from data_pipelines_annuaire.helpers import Notification, ObjectStorageClient
+from data_pipelines_annuaire.helpers import (
+    EmailNotification,
+    Notification,
+    ObjectStorageClient,
+)
 from data_pipelines_annuaire.helpers.flush_cache import flush_redis_cache
 from data_pipelines_annuaire.tests.e2e_tests.run_tests import run_e2e_tests
 from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.task_functions.index import (
@@ -57,7 +60,7 @@ default_args = {
     tags=["index", "elasticsearch"],
     catchup=False,
     max_active_runs=1,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
 )
 def index_elasticsearch():

--- a/workflows/data_pipelines/elasticsearch/dag_rollback.py
+++ b/workflows/data_pipelines/elasticsearch/dag_rollback.py
@@ -1,13 +1,12 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag
 
 from data_pipelines_annuaire.config import (
     AIRFLOW_SNAPSHOT_ROLLBACK_DAG_NAME,
     EMAIL_LIST,
 )
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.task_functions.downstream import (
     wait_for_downstream_rollback_import,
 )
@@ -31,7 +30,7 @@ default_args = {
     tags=["siren"],
     catchup=False,
     max_active_runs=1,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
 )
 def snapshot_index_rollback():

--- a/workflows/data_pipelines/elasticsearch/dag_snapshot_data.py
+++ b/workflows/data_pipelines/elasticsearch/dag_snapshot_data.py
@@ -1,13 +1,12 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag
 
 from data_pipelines_annuaire.config import (
     AIRFLOW_SNAPSHOT_DAG_NAME,
     EMAIL_LIST,
 )
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.task_functions.downstream import (
     update_downstream_alias,
     wait_for_downstream_import,
@@ -34,7 +33,7 @@ default_args = {
     tags=["siren"],
     catchup=False,
     max_active_runs=1,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
 )
 def snapshot_index():

--- a/workflows/data_pipelines/ess_france/dag.py
+++ b/workflows/data_pipelines/ess_france/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.ess_france.config import (
     ESS_CONFIG,
 )
@@ -28,7 +27,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
 )
 def data_processing_ess_france():

--- a/workflows/data_pipelines/etl/dag.py
+++ b/workflows/data_pipelines/etl/dag.py
@@ -1,7 +1,6 @@
 import os
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.sdk import dag, task, task_group
 
@@ -11,7 +10,7 @@ from data_pipelines_annuaire.config import (
     EMAIL_LIST,
     SIRENE_DATABASE_LOCATION,
 )
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.helpers.database_constructor import (
     DatabaseTableConstructor,
 )
@@ -146,7 +145,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,  # False to ignore past runs
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/export_bodacc_radiations/dag.py
+++ b/workflows/data_pipelines/export_bodacc_radiations/dag.py
@@ -1,6 +1,5 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, setup, task, teardown
 
 from data_pipelines_annuaire.config import (
@@ -8,7 +7,7 @@ from data_pipelines_annuaire.config import (
     EMAIL_LIST,
     EXPORT_DATA_DIR,
 )
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.export_bodacc_radiations.processor import (
     ExportFile,
     export_file,
@@ -34,7 +33,7 @@ default_args = {
     params={},
     catchup=False,
     max_active_runs=1,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
 )
 def export_bodacc_radiations():

--- a/workflows/data_pipelines/finess/geographique/dag.py
+++ b/workflows/data_pipelines/finess/geographique/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.finess.geographique.config import (
     FINESS_GEOGRAPHIQUE_CONFIG,
 )
@@ -26,7 +25,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/finess/juridique/dag.py
+++ b/workflows/data_pipelines/finess/juridique/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.finess.juridique.config import (
     FINESS_JURIDIQUE_CONFIG,
 )
@@ -26,7 +25,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/fondation/dag.py
+++ b/workflows/data_pipelines/fondation/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.fondation.processor import (
     FondationProcessor,
 )
@@ -23,7 +22,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/formation/dag.py
+++ b/workflows/data_pipelines/formation/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.formation.config import (
     FORMATION_CONFIG,
 )
@@ -26,7 +25,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/marche_inclusion/dag.py
+++ b/workflows/data_pipelines/marche_inclusion/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.marche_inclusion.processor import (
     MarcheInclusionProcessor,
 )
@@ -23,7 +22,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/metadata/cc/dag.py
+++ b/workflows/data_pipelines/metadata/cc/dag.py
@@ -1,11 +1,10 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.providers.standard.operators.python import ShortCircuitOperator
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST, METADATA_CC_TMP_FOLDER
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.metadata.cc.task_functions import (
     create_metadata_convention_collective_json,
     is_metadata_not_updated,
@@ -26,7 +25,7 @@ default_args = {
     catchup=False,
     max_active_runs=1,
     dagrun_timeout=timedelta(minutes=(60 * 100)),
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     tags=["api", "metadata", "cc"],
 )

--- a/workflows/data_pipelines/patrimoine_vivant/dag.py
+++ b/workflows/data_pipelines/patrimoine_vivant/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.patrimoine_vivant.processor import (
     PatrimoineVivantProcessor,
 )
@@ -23,7 +22,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60 * 5),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/rge/dag.py
+++ b/workflows/data_pipelines/rge/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.rge.config import RGE_CONFIG
 from data_pipelines_annuaire.workflows.data_pipelines.rge.processor import (
     RgeProcessor,
@@ -25,7 +24,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/rne/database/dag.py
+++ b/workflows/data_pipelines/rne/database/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST, RNE_DB_TMP_FOLDER
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.rne.database.task_functions import (
     check_db_count,
     create_db,
@@ -30,7 +29,7 @@ default_args = {
     default_args=default_args,
     schedule="0 2 * * *",  # Run daily at 2 am
     start_date=datetime(2026, 1, 1, tzinfo=UTC),
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
     dagrun_timeout=timedelta(minutes=(60 * 200)),

--- a/workflows/data_pipelines/rne/flux/dag.py
+++ b/workflows/data_pipelines/rne/flux/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST, RNE_FLUX_TMP_FOLDER
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.rne.flux.flux_tasks import (
     get_every_day_flux,
 )
@@ -25,7 +24,7 @@ default_args = {
     dagrun_timeout=timedelta(days=30),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
 )
 def get_flux_rne():

--- a/workflows/data_pipelines/rne/maintenance/dag.py
+++ b/workflows/data_pipelines/rne/maintenance/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.helpers.object_storage import ObjectStorageClient
 
 default_args = {
@@ -27,7 +26,7 @@ def rename_old_rne_folders():
     start_date=datetime(2026, 1, 1, tzinfo=UTC),
     dagrun_timeout=timedelta(minutes=(60 * 8)),
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,  # Allow only one execution at a time
 )

--- a/workflows/data_pipelines/rne/stock/dag.py
+++ b/workflows/data_pipelines/rne/stock/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.rne.stock.processor import (
     RneStockProcessor,
 )
@@ -25,7 +24,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60 * 18),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/sirene/flux/dag.py
+++ b/workflows/data_pipelines/sirene/flux/dag.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 import pendulum
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.sdk import dag, task
 
@@ -9,7 +8,7 @@ from data_pipelines_annuaire.config import (
     AIRFLOW_ETL_DAG_NAME,
     EMAIL_LIST,
 )
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.sirene.flux.processor import (
     SireneFluxProcessor,
 )
@@ -29,7 +28,7 @@ default_args = {
     params={},
     catchup=False,
     max_active_runs=1,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
 )
 def data_processing_sirene_flux():

--- a/workflows/data_pipelines/sirene/stock/dag.py
+++ b/workflows/data_pipelines/sirene/stock/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.sirene.stock.processor import (
     SireneStockProcessor,
 )
@@ -24,7 +23,7 @@ default_args = {
     params={},
     catchup=False,
     max_active_runs=1,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
 )
 def data_processing_sirene_stock():

--- a/workflows/data_pipelines/spectacle/dag.py
+++ b/workflows/data_pipelines/spectacle/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.spectacle.config import (
     SPECTACLE_CONFIG,
 )
@@ -26,7 +25,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/data_pipelines/tva/dag.py
+++ b/workflows/data_pipelines/tva/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.tva.config import (
     TVA_CONFIG,
 )
@@ -28,7 +27,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=60),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
 )
 def data_processing_tva():

--- a/workflows/data_pipelines/uai/dag.py
+++ b/workflows/data_pipelines/uai/dag.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import EMAIL_LIST
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.workflows.data_pipelines.uai.config import (
     UAI_CONFIG,
 )
@@ -26,7 +25,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=15),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/maintenance/dag_clean_object_storage.py
+++ b/workflows/maintenance/dag_clean_object_storage.py
@@ -3,14 +3,13 @@ import re
 from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag, task
 
 from data_pipelines_annuaire.config import (
     EMAIL_LIST,
     OBJECT_STORAGE_ENV_PATH,
 )
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.helpers.object_storage import ObjectStorageClient
 
 logger = logging.getLogger(__name__)
@@ -75,7 +74,7 @@ default_args = {
     start_date=datetime(2026, 1, 1, tzinfo=UTC),
     dagrun_timeout=timedelta(minutes=30),
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,  # Allow only one execution at a time
 )

--- a/workflows/maintenance/dag_flush_and_execute_queries.py
+++ b/workflows/maintenance/dag_flush_and_execute_queries.py
@@ -1,6 +1,5 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag
 
 from data_pipelines_annuaire.config import (
@@ -10,7 +9,7 @@ from data_pipelines_annuaire.config import (
     REDIS_PASSWORD,
     REDIS_PORT,
 )
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.helpers.execute_slow_queries import (
     execute_slow_requests,
 )
@@ -29,7 +28,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=10),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )

--- a/workflows/maintenance/dag_flush_cache_only.py
+++ b/workflows/maintenance/dag_flush_cache_only.py
@@ -1,6 +1,5 @@
 from datetime import UTC, datetime, timedelta
 
-from airflow.providers.smtp.notifications.smtp import SmtpNotifier
 from airflow.sdk import dag
 
 from data_pipelines_annuaire.config import (
@@ -10,7 +9,7 @@ from data_pipelines_annuaire.config import (
     REDIS_PASSWORD,
     REDIS_PORT,
 )
-from data_pipelines_annuaire.helpers import Notification
+from data_pipelines_annuaire.helpers import EmailNotification, Notification
 from data_pipelines_annuaire.helpers.flush_cache import flush_redis_cache
 
 default_args = {
@@ -28,7 +27,7 @@ default_args = {
     dagrun_timeout=timedelta(minutes=5),
     params={},
     catchup=False,
-    on_failure_callback=[Notification(), SmtpNotifier(to=EMAIL_LIST)],
+    on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],
     on_success_callback=Notification(),
     max_active_runs=1,
 )


### PR DESCRIPTION
Closes https://github.com/annuaire-entreprises-data-gouv-fr/search-infra/issues/831

More explicit and easier to read.

Email template generated with Mistral.

<img width="674" height="777" alt="image" src="https://github.com/user-attachments/assets/45975745-9e2d-4196-914b-dc0455541200" />

Tested on dev-01 ✅ 