### PR TITLE
perf(indexation): increase speed

### DIFF
--- a/config.py
+++ b/config.py
@@ -136,14 +136,18 @@ ELASTIC_USER = Variable.get("ELASTIC_USER", None)
 ELASTIC_BULK_THREAD_COUNT = int(Variable.get("ELASTIC_BULK_THREAD_COUNT", 4))
 ELASTIC_BULK_SIZE = int(Variable.get("ELASTIC_BULK_SIZE", 1500))
 ELASTIC_SHARDS = 2
-# Number of siren ranges fill_elastic_siren_index is split into. The task is bound by a
-# single Python thread, so this is a core count, not an Elasticsearch setting: the VM
-# has 12 and also runs the scheduler and the rest of the stack.
-ELASTIC_INDEXING_SHARD_COUNT = 8
+# Bulk requests take far longer than the 10s default once the cluster is saturated, and a
+# timeout re-sends the whole bulk to a cluster that is already struggling. Seconds.
+ELASTIC_REQUEST_TIMEOUT = 60
 ELASTIC_REPLICAS = 0
 ELASTIC_MIN_DOC_COUNT_EXPECTED = int(
     Variable.get("ELASTIC_MIN_DOC_COUNT_EXPECTED", 26000000)
 )
+
+# Number of siren ranges fill_elastic_siren_index is split into, one mapped task each.
+# Nothing to do with ELASTIC_SHARDS above: this is a core count, the VM has 12 and also
+# runs the scheduler and the rest of the stack.
+INDEXING_SIREN_RANGES = 8
 
 ELASTIC_MAX_LIVE_VERSIONS = int(Variable.get("ELASTIC_MAX_LIVE_VERSIONS", 2))
 

--- a/config.py
+++ b/config.py
@@ -145,9 +145,10 @@ ELASTIC_MIN_DOC_COUNT_EXPECTED = int(
 )
 
 # Number of siren ranges fill_elastic_siren_index is split into, one mapped task each.
-# Nothing to do with ELASTIC_SHARDS above: this is a core count, the VM has 12 and also
-# runs the scheduler and the rest of the stack.
-INDEXING_SIREN_RANGES = 8
+# Nothing to do with ELASTIC_SHARDS above. Four producers move ~14 000 documents/s where
+# the single-node cluster tops out around 7 500, so more only burns CPU: at 8 the phase
+# timings were inflated x2.5 by contention for no gain in wall clock.
+INDEXING_SIREN_RANGES = 4
 
 ELASTIC_MAX_LIVE_VERSIONS = int(Variable.get("ELASTIC_MAX_LIVE_VERSIONS", 2))
 

--- a/config.py
+++ b/config.py
@@ -136,6 +136,10 @@ ELASTIC_USER = Variable.get("ELASTIC_USER", None)
 ELASTIC_BULK_THREAD_COUNT = int(Variable.get("ELASTIC_BULK_THREAD_COUNT", 4))
 ELASTIC_BULK_SIZE = int(Variable.get("ELASTIC_BULK_SIZE", 1500))
 ELASTIC_SHARDS = 2
+# Number of siren ranges fill_elastic_siren_index is split into. The task is bound by a
+# single Python thread, so this is a core count, not an Elasticsearch setting: the VM
+# has 12 and also runs the scheduler and the rest of the stack.
+ELASTIC_INDEXING_SHARD_COUNT = 8
 ELASTIC_REPLICAS = 0
 ELASTIC_MIN_DOC_COUNT_EXPECTED = int(
     Variable.get("ELASTIC_MIN_DOC_COUNT_EXPECTED", 26000000)

--- a/helpers/sqlite_client.py
+++ b/helpers/sqlite_client.py
@@ -23,6 +23,9 @@ class SqliteClient:
     Args:
         db_location (str): The file path to the SQLite database. The database file will be created if it does not exist.
         timeout (int, optional): The timeout duration for database operations. Defaults to 30 seconds.
+        check_same_thread (bool, optional): Whether the connection may only be used by the
+            thread that created it. Set to False when a cursor is drained by another thread,
+            which is only safe as long as access stays sequential. Defaults to True.
 
     Example:
         ```python
@@ -44,7 +47,7 @@ class SqliteClient:
         ```
     """
 
-    def __init__(self, db_location, timeout=30) -> None:
+    def __init__(self, db_location, timeout=30, check_same_thread=True) -> None:
         self.db_location = db_location
 
         # SQLite creates the database if it does not exist but not the parent folders
@@ -52,7 +55,9 @@ class SqliteClient:
         if not os.path.exists(self.db_folder):
             os.makedirs(self.db_folder)
 
-        self.db_conn = sqlite3.connect(self.db_location, timeout=timeout)
+        self.db_conn = sqlite3.connect(
+            self.db_location, timeout=timeout, check_same_thread=check_same_thread
+        )
         logger.info(
             f"*********** Connecting to database {self.db_location}! ***********"
         )

--- a/helpers/sqlite_client.py
+++ b/helpers/sqlite_client.py
@@ -9,6 +9,18 @@ from data_pipelines_annuaire.helpers.filesystem import LocalFile
 
 logger = logging.getLogger(__name__)
 
+# Applied per connection, and only where asked for: these trade memory for read speed
+# and would be wasted (or harmful) on the small write connections of the ETL.
+LARGE_SCAN_PRAGMAS = (
+    # 256 MB of page cache instead of the 2 MB default. Negative means KiB.
+    "PRAGMA cache_size = -262144",
+    # Read pages through mmap rather than copying them into the process. SQLite clamps
+    # this to its compile-time maximum, and only the pages actually touched are mapped,
+    # so an oversized value is safe and costs no resident memory.
+    "PRAGMA mmap_size = 30000000000",
+    "PRAGMA temp_store = MEMORY",
+)
+
 
 class SqliteClient:
     """
@@ -73,6 +85,16 @@ class SqliteClient:
         else:
             self.db_conn.commit()
         self.db_conn.close()
+
+    def tune_for_large_scan(self) -> None:
+        """Tune this connection for a long read, such as the indexing query.
+
+        The defaults are sized for the small transactions of the ETL: 2 MB of page
+        cache and no mmap, against a multi-GB database read row by row with tens of
+        index lookups per row. Call this after connecting and before the query.
+        """
+        for pragma in LARGE_SCAN_PRAGMAS:
+            self.execute(pragma)
 
     def commit_and_close_conn(self) -> None:
         self.db_conn.commit()

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -11,6 +11,7 @@ from typing import Literal
 from unicodedata import normalize
 from urllib.parse import urlparse
 
+import orjson
 import pandas as pd
 import requests
 
@@ -18,6 +19,25 @@ from data_pipelines_annuaire.config import AIRFLOW_ENV
 from data_pipelines_annuaire.helpers.datagouv import fetch_last_modified_date
 
 logger = logging.getLogger(__name__)
+
+# "2026-08-31 09:44:01+00:00", the shape SQLite stores. %z also accepts other forms,
+# which is why anything that does not match falls back to the parser.
+RNE_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[+-]\d{2}:?\d{2}$")
+
+
+def load_json(value):
+    """Parse JSON built by SQLite, roughly twice as fast as the standard library.
+
+    orjson rejects the non-finite numbers SQLite renders for an infinite REAL
+    (`json_object` turns one into `9.0e+999`), where the standard library returns `inf`.
+    Such a row is vanishingly rare but the blast radius is a whole siren range, so the
+    fallback keeps the old behaviour for it. A genuinely malformed payload still raises,
+    from the standard library, exactly as before.
+    """
+    try:
+        return orjson.loads(value)
+    except ValueError:
+        return json.loads(value)
 
 
 def check_if_prod():
@@ -184,9 +204,15 @@ def get_last_line(file_path):
 
 
 def convert_date_format(original_date_string):
+    if original_date_string is None:
+        return None
+
+    # strptime + strftime costs ~40us and this runs once per unite legale. The offset is
+    # dropped rather than applied, so on the usual shape the conversion is a slice.
+    if RNE_DATE_PATTERN.match(original_date_string):
+        return f"{original_date_string[:10]}T{original_date_string[11:19]}"
+
     try:
-        if original_date_string is None:
-            return None
         # Convert to datetime object
         original_datetime = datetime.strptime(
             original_date_string, "%Y-%m-%d %H:%M:%S%z"

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -588,9 +588,12 @@ def get_dates_since_start_of_month(
 
 
 def load_file(file_name: str):
-    labels_file_path = "dags/data_pipelines_annuaire/helpers/labels/"
+    # Resolved from the package instead of the working directory: the labels used to
+    # be reachable only from the Airflow container, so importing any module reading
+    # one (data_enrichment and everything downstream of it) failed everywhere else.
+    labels_file_path = Path(__file__).parent / "labels"
 
-    with open(f"{labels_file_path}{file_name}") as json_file:
+    with open(labels_file_path / file_name) as json_file:
         file_decoded = json.load(json_file)
     return file_decoded
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ boto3==1.43.69
 pandas==2.3.3
 openpyxl==3.1.5
 elasticsearch==9.2.1
+orjson==3.12.0
 requests==2.34.2
 pytest==9.1.1
 pydantic==2.13.4

--- a/tests/unit_tests/test_index_sharding.py
+++ b/tests/unit_tests/test_index_sharding.py
@@ -1,0 +1,146 @@
+from itertools import pairwise
+
+import pytest
+
+from data_pipelines_annuaire.helpers.sqlite_client import SqliteClient
+from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.sqlite.fields_to_index import (
+    select_fields_to_index_query,
+)
+from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.task_functions.index import (
+    compute_siren_ranges,
+)
+
+SHARD_COUNT = 4
+UNITES_LEGALES_COUNT = 100
+
+
+@pytest.fixture
+def sqlite_client(tmp_path):
+    client = SqliteClient(str(tmp_path / "sirene.db"))
+    client.execute("CREATE TABLE unite_legale (siren TEXT)")
+    client.execute(
+        "CREATE UNIQUE INDEX index_unite_legale_siren ON unite_legale (siren)"
+    )
+    client.db_cursor.executemany(
+        "INSERT INTO unite_legale VALUES (?)",
+        [(f"{siren:09d}",) for siren in range(UNITES_LEGALES_COUNT)],
+    )
+    yield client
+    client.db_conn.close()
+
+
+def count_in_range(sqlite_client, siren_start, siren_end):
+    predicates, params = [], []
+    if siren_start is not None:
+        predicates.append("AND siren >= ?")
+        params.append(siren_start)
+    if siren_end is not None:
+        predicates.append("AND siren < ?")
+        params.append(siren_end)
+    query = f"SELECT count(*) FROM unite_legale WHERE 1 {' '.join(predicates)}"
+    return sqlite_client.execute(query, params).fetchone()[0]
+
+
+# compute_siren_ranges()
+
+
+def test_siren_ranges_tile_the_table_without_gap_or_overlap(sqlite_client):
+    _, siren_ranges = compute_siren_ranges(sqlite_client, SHARD_COUNT)
+
+    assert len(siren_ranges) == SHARD_COUNT
+    assert siren_ranges[0]["siren_start"] is None
+    assert siren_ranges[-1]["siren_end"] is None
+    for current, following in pairwise(siren_ranges):
+        assert current["siren_end"] == following["siren_start"]
+
+
+def test_siren_ranges_are_balanced_and_cover_every_row(sqlite_client):
+    _, siren_ranges = compute_siren_ranges(sqlite_client, SHARD_COUNT)
+
+    counts = [
+        count_in_range(sqlite_client, **siren_range) for siren_range in siren_ranges
+    ]
+
+    assert sum(counts) == UNITES_LEGALES_COUNT
+    assert counts == [UNITES_LEGALES_COUNT // SHARD_COUNT] * SHARD_COUNT
+
+
+def test_siren_ranges_never_lose_rows_when_there_are_fewer_rows_than_shards(
+    sqlite_client,
+):
+    sqlite_client.execute("DELETE FROM unite_legale WHERE siren > '000000001'")
+
+    unites_legales_count, siren_ranges = compute_siren_ranges(
+        sqlite_client, SHARD_COUNT
+    )
+
+    assert unites_legales_count == 2
+    counts = [
+        count_in_range(sqlite_client, **siren_range) for siren_range in siren_ranges
+    ]
+    assert sum(counts) == 2
+
+
+def test_siren_ranges_of_an_empty_table_is_a_single_unbounded_range(sqlite_client):
+    sqlite_client.execute("DELETE FROM unite_legale")
+
+    unites_legales_count, siren_ranges = compute_siren_ranges(
+        sqlite_client, SHARD_COUNT
+    )
+
+    assert unites_legales_count == 0
+    assert siren_ranges == [{"siren_start": None, "siren_end": None}]
+
+
+# select_fields_to_index_query()
+
+
+def test_query_without_bounds_has_no_predicate_and_no_parameter():
+    query, params = select_fields_to_index_query()
+
+    assert "ul.siren >=" not in query
+    assert "ul.siren <" not in query
+    assert params == []
+
+
+def test_query_bounds_are_appended_in_parameter_order():
+    query, params = select_fields_to_index_query(
+        siren_start="356000000", siren_end="552100554"
+    )
+
+    assert query.index("ul.siren >= ?") < query.index("ul.siren < ?")
+    assert params == ["356000000", "552100554"]
+
+
+@pytest.mark.parametrize(
+    "siren_range, expected_predicate, expected_params",
+    [
+        ({"siren_start": "356000000"}, "ul.siren >= ?", ["356000000"]),
+        ({"siren_end": "356000000"}, "ul.siren < ?", ["356000000"]),
+    ],
+)
+def test_query_with_a_single_bound(siren_range, expected_predicate, expected_params):
+    query, params = select_fields_to_index_query(**siren_range)
+
+    assert expected_predicate in query
+    assert params == expected_params
+
+
+def test_query_ranges_are_valid_sql_and_select_their_shard(sqlite_client):
+    """The generated SQL must run: a typo in the predicate would only show up on a
+    3-hour run otherwise."""
+    _, siren_ranges = compute_siren_ranges(sqlite_client, SHARD_COUNT)
+
+    for siren_range in siren_ranges:
+        _, params = select_fields_to_index_query(**siren_range)
+        predicates = " ".join(
+            predicate
+            for predicate, bound in (
+                ("AND ul.siren >= ?", siren_range["siren_start"]),
+                ("AND ul.siren < ?", siren_range["siren_end"]),
+            )
+            if bound is not None
+        )
+        query = f"SELECT count(*) FROM unite_legale ul WHERE 1 {predicates}"
+
+        assert sqlite_client.execute(query, params).fetchone()[0] > 0

--- a/tests/unit_tests/test_indexing_unite_legale.py
+++ b/tests/unit_tests/test_indexing_unite_legale.py
@@ -1,0 +1,134 @@
+from types import SimpleNamespace
+
+import pytest
+from elastic_transport import SerializerCollection
+from elasticsearch import Elasticsearch
+from elasticsearch.helpers import expand_action, parallel_bulk
+
+from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.indexing_unite_legale import (
+    JSON_MIMETYPE,
+    ProducerTimings,
+    TimedJsonSerializer,
+    time_bulk_encoding,
+    timed_expand_action,
+)
+
+
+@pytest.fixture
+def timings():
+    return ProducerTimings()
+
+
+@pytest.fixture
+def elastic_connection():
+    return SimpleNamespace(
+        transport=SimpleNamespace(serializers=SerializerCollection())
+    )
+
+
+def test_busy_sums_every_phase_running_on_the_producer_thread():
+    timings = ProducerTimings(
+        fetch=1.0, transform=2.0, build_documents=4.0, expand=8.0, serialize=16.0
+    )
+
+    assert timings.bulk_encode == 24.0
+    assert timings.busy == 31.0
+
+
+def test_timed_json_serializer_returns_the_wrapped_result_and_accumulates(timings):
+    serializer = SerializerCollection().get_serializer(JSON_MIMETYPE)
+    timed_serializer = TimedJsonSerializer(serializer, timings)
+
+    assert timed_serializer.dumps({"siren": "356000000"}) == serializer.dumps(
+        {"siren": "356000000"}
+    )
+    assert timings.serialize > 0
+
+    first_measure = timings.serialize
+    timed_serializer.dumps({"siren": "552100554"})
+
+    assert timings.serialize > first_measure
+
+
+def test_timed_json_serializer_delegates_everything_but_dumps(timings):
+    serializer = SerializerCollection().get_serializer(JSON_MIMETYPE)
+    timed_serializer = TimedJsonSerializer(serializer, timings)
+
+    # Responses are decoded by the bulk worker threads, so loads must stay untimed.
+    assert timed_serializer.loads(b'{"siren": "356000000"}') == {"siren": "356000000"}
+    assert timings.serialize == 0
+    assert timed_serializer.mimetype == serializer.mimetype
+
+
+def test_timed_expand_action_matches_expand_action_and_accumulates(timings):
+    document = {"_index": "siren-20260827", "_id": "356000000-100", "nom": "SNCF"}
+
+    expanded = timed_expand_action(timings)(dict(document))
+
+    assert expanded == expand_action(dict(document))
+    assert timings.expand > 0
+
+
+def test_time_bulk_encoding_installs_the_timing_serializer(elastic_connection, timings):
+    serializers = elastic_connection.transport.serializers
+    original_serializer = serializers.get_serializer(JSON_MIMETYPE)
+
+    with time_bulk_encoding(elastic_connection, timings):
+        installed_serializer = serializers.get_serializer(JSON_MIMETYPE)
+        installed_serializer.dumps({"siren": "356000000"})
+
+    assert isinstance(installed_serializer, TimedJsonSerializer)
+    assert timings.serialize > 0
+    assert serializers.get_serializer(JSON_MIMETYPE) is original_serializer
+
+
+def test_time_bulk_encoding_restores_the_serializer_on_failure(
+    elastic_connection, timings
+):
+    serializers = elastic_connection.transport.serializers
+    original_serializer = serializers.get_serializer(JSON_MIMETYPE)
+
+    with pytest.raises(ValueError), time_bulk_encoding(elastic_connection, timings):
+        raise ValueError("indexing failed")
+
+    assert serializers.get_serializer(JSON_MIMETYPE) is original_serializer
+
+
+def test_parallel_bulk_feeds_both_counters(timings):
+    """Guard the wiring: parallel_bulk must reach the wrapped serializer and the
+    wrapped expand_action, otherwise the run reports a silent zero and the missing
+    wall clock is blamed on Elasticsearch again."""
+    client = Elasticsearch("http://elastic.test:9200")
+    documents = [
+        {"_index": "siren-20260827", "_id": f"{siren}-100", "nom_complet": "SNCF"}
+        for siren in range(100)
+    ]
+
+    def fake_bulk(*args, operations, **kwargs):
+        # One response item per action/source pair of the ndjson payload.
+        return SimpleNamespace(
+            body={
+                "errors": False,
+                "items": [
+                    {"index": {"status": 201}} for _ in range(len(operations) // 2)
+                ],
+            }
+        )
+
+    client.bulk = fake_bulk
+
+    with time_bulk_encoding(client, timings):
+        indexed = sum(
+            success
+            for success, _ in parallel_bulk(
+                client,
+                documents,
+                thread_count=2,
+                chunk_size=10,
+                expand_action_callback=timed_expand_action(timings),
+            )
+        )
+
+    assert indexed == len(documents)
+    assert timings.expand > 0
+    assert timings.serialize > 0

--- a/tests/unit_tests/test_indexing_unite_legale.py
+++ b/tests/unit_tests/test_indexing_unite_legale.py
@@ -1,16 +1,25 @@
+import logging
 from types import SimpleNamespace
 
 import pytest
-from elastic_transport import SerializerCollection
+from elastic_transport import JsonSerializer, OrjsonSerializer, SerializerCollection
 from elasticsearch import Elasticsearch
 from elasticsearch.helpers import expand_action, parallel_bulk
 
+from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch import (
+    indexing_unite_legale,
+)
 from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.indexing_unite_legale import (
     JSON_MIMETYPE,
     ProducerTimings,
     TimedJsonSerializer,
-    time_bulk_encoding,
+    doc_unite_legale_generator,
+    generate_unite_legale_docs,
+    orjson_bulk_serializer,
     timed_expand_action,
+)
+from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.structure_type import (
+    StructureType,
 )
 
 
@@ -69,26 +78,29 @@ def test_timed_expand_action_matches_expand_action_and_accumulates(timings):
     assert timings.expand > 0
 
 
-def test_time_bulk_encoding_installs_the_timing_serializer(elastic_connection, timings):
-    serializers = elastic_connection.transport.serializers
-    original_serializer = serializers.get_serializer(JSON_MIMETYPE)
-
-    with time_bulk_encoding(elastic_connection, timings):
-        installed_serializer = serializers.get_serializer(JSON_MIMETYPE)
-        installed_serializer.dumps({"siren": "356000000"})
-
-    assert isinstance(installed_serializer, TimedJsonSerializer)
-    assert timings.serialize > 0
-    assert serializers.get_serializer(JSON_MIMETYPE) is original_serializer
-
-
-def test_time_bulk_encoding_restores_the_serializer_on_failure(
+def test_orjson_bulk_serializer_installs_orjson_and_times_it(
     elastic_connection, timings
 ):
     serializers = elastic_connection.transport.serializers
     original_serializer = serializers.get_serializer(JSON_MIMETYPE)
 
-    with pytest.raises(ValueError), time_bulk_encoding(elastic_connection, timings):
+    with orjson_bulk_serializer(elastic_connection, timings):
+        installed_serializer = serializers.get_serializer(JSON_MIMETYPE)
+        installed_serializer.dumps({"siren": "356000000"})
+
+    assert isinstance(installed_serializer, TimedJsonSerializer)
+    assert isinstance(installed_serializer._serializer, OrjsonSerializer)
+    assert timings.serialize > 0
+    assert serializers.get_serializer(JSON_MIMETYPE) is original_serializer
+
+
+def test_orjson_bulk_serializer_restores_the_serializer_on_failure(
+    elastic_connection, timings
+):
+    serializers = elastic_connection.transport.serializers
+    original_serializer = serializers.get_serializer(JSON_MIMETYPE)
+
+    with pytest.raises(ValueError), orjson_bulk_serializer(elastic_connection, timings):
         raise ValueError("indexing failed")
 
     assert serializers.get_serializer(JSON_MIMETYPE) is original_serializer
@@ -117,7 +129,7 @@ def test_parallel_bulk_feeds_both_counters(timings):
 
     client.bulk = fake_bulk
 
-    with time_bulk_encoding(client, timings):
+    with orjson_bulk_serializer(client, timings):
         indexed = sum(
             success
             for success, _ in parallel_bulk(
@@ -132,3 +144,130 @@ def test_parallel_bulk_feeds_both_counters(timings):
     assert indexed == len(documents)
     assert timings.expand > 0
     assert timings.serialize > 0
+
+
+def processed_unite_legale(nombre_etablissements=1):
+    """A document in the shape `doc_unite_legale_generator` receives, with the value
+    types that survive `process_unites_legales`: accents, None, bool, int, float,
+    the `StructureType` enum, empty and nested containers."""
+    etablissement = {
+        "siret": "35600000000048",
+        "nom_complet": "SOCIÉTÉ NATIONALE DES CHEMINS DE FER FRANÇAIS",
+        "adresse": "2 PLACE AUX ÉTOILES 93200 SAINT-DENIS",
+        "est_siege": True,
+        "ancien_siege": False,
+        "latitude": 48.936,
+        "longitude": 2.357,
+        "liste_idcc": None,
+        "liste_rge": [],
+        "liste_uai": ["0930943C"],
+        "successions": {"predecesseurs": [], "successeurs": None},
+        "date_creation": "1983-01-01",
+    }
+    return {
+        "identifiant": "356000000",
+        "type_structure": [StructureType.UNITE_LEGALE, StructureType.FONDATION],
+        "nom_complet": "SOCIÉTÉ NATIONALE DES CHEMINS DE FER FRANÇAIS",
+        "fondation": None,
+        "unite_legale": {
+            "siren": "356000000",
+            "nom_complet": "SOCIÉTÉ NATIONALE DES CHEMINS DE FER FRANÇAIS",
+            "sigle": "SNCF",
+            "est_association": False,
+            "nombre_etablissements_ouverts": 2843,
+            "facteur_taille_entreprise": 25.5,
+            "date_mise_a_jour": "2026-08-31T09:44:01",
+            "date_creation_unite_legale": "1983-01-01",
+            "bilan_financier": {"ca": 1000000, "resultat_net": -50000},
+            "immatriculation": {},
+            "liste_dirigeants": ["JEAN DUPONT"],
+            "etablissements": [
+                dict(etablissement, siret=f"3560000000{index:04d}")
+                for index in range(nombre_etablissements)
+            ],
+        },
+    }
+
+
+@pytest.mark.parametrize("nombre_etablissements", [1, 150])
+def test_orjson_encodes_our_documents_exactly_like_the_standard_library(
+    nombre_etablissements,
+):
+    """orjson is stricter than the standard library (no tuples, no non-str keys) and
+    encodes dates natively instead of going through `default`. Guard that the payloads
+    we actually send are unchanged — including the >100 établissements split, whose
+    documents go through a different branch."""
+    documents = list(
+        doc_unite_legale_generator(
+            [processed_unite_legale(nombre_etablissements)], "siren-20260831"
+        )
+    )
+
+    assert documents
+    for document in documents:
+        assert OrjsonSerializer().dumps(document) == JsonSerializer().dumps(document)
+
+
+class FakeCursor:
+    """Minimal stand-in for the sqlite cursor drained by the producer."""
+
+    description = (("siren",),)
+
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def fetchmany(self, size):
+        batch, self._rows = self._rows[:size], self._rows[size:]
+        return batch
+
+
+@pytest.fixture
+def cursor_and_transform(monkeypatch):
+    monkeypatch.setattr(
+        indexing_unite_legale,
+        "process_unites_legales",
+        lambda rows: [processed_unite_legale() for _ in rows],
+    )
+    return FakeCursor([("356000000",)] * 4)
+
+
+def transform_profiles(caplog):
+    return [
+        record.message
+        for record in caplog.records
+        if "Transform profile" in record.message
+    ]
+
+
+def test_transform_profile_is_logged_once_when_armed(
+    cursor_and_transform, caplog, monkeypatch, timings
+):
+    monkeypatch.setattr(indexing_unite_legale, "PROFILE_TRANSFORM_UNITES_LEGALES", 2)
+
+    with caplog.at_level(logging.INFO):
+        list(
+            generate_unite_legale_docs(
+                cursor_and_transform, 1, "siren-20260831", timings
+            )
+        )
+
+    profiles = transform_profiles(caplog)
+    assert len(profiles) == 1
+    assert "Ordered by: cumulative time" in profiles[0]
+    assert "Ordered by: internal time" in profiles[0]
+
+
+def test_transform_is_not_profiled_when_disabled(
+    cursor_and_transform, caplog, monkeypatch, timings
+):
+    monkeypatch.setattr(indexing_unite_legale, "PROFILE_TRANSFORM_UNITES_LEGALES", 0)
+
+    with caplog.at_level(logging.INFO):
+        documents = list(
+            generate_unite_legale_docs(
+                cursor_and_transform, 1, "siren-20260831", timings
+            )
+        )
+
+    assert documents
+    assert transform_profiles(caplog) == []

--- a/tests/unit_tests/test_sqlite_client.py
+++ b/tests/unit_tests/test_sqlite_client.py
@@ -34,3 +34,29 @@ def test_to_csv_empty_result_writes_header_only(sqlite_client, tmp_path):
 
     assert output.read_text().splitlines() == ["id,name"]
     assert local_file.lines_count() == 1
+
+
+# SqliteClient.tune_for_large_scan()
+
+
+def test_tune_for_large_scan_applies_the_pragmas(sqlite_client):
+    assert sqlite_client.execute("PRAGMA cache_size").fetchone()[0] != -262144
+
+    sqlite_client.tune_for_large_scan()
+
+    assert sqlite_client.execute("PRAGMA cache_size").fetchone()[0] == -262144
+    # 2 is MEMORY, 0 the default.
+    assert sqlite_client.execute("PRAGMA temp_store").fetchone()[0] == 2
+    # SQLite clamps mmap_size to its compile-time maximum, so only the fact that
+    # mapping is enabled can be asserted portably.
+    assert sqlite_client.execute("PRAGMA mmap_size").fetchone()[0] > 0
+
+
+def test_tune_for_large_scan_leaves_other_connections_alone(sqlite_client, tmp_path):
+    sqlite_client.tune_for_large_scan()
+
+    untuned_client = SqliteClient(str(tmp_path / "untuned.db"))
+    try:
+        assert untuned_client.execute("PRAGMA cache_size").fetchone()[0] != -262144
+    finally:
+        untuned_client.db_conn.close()

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -1,11 +1,16 @@
 import logging
 import os
 import tempfile
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from data_pipelines_annuaire.helpers.utils import fetch_hyperlink_from_page
+from data_pipelines_annuaire.helpers.utils import (
+    convert_date_format,
+    fetch_hyperlink_from_page,
+    load_json,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -136,3 +141,63 @@ def test_fetch_hyperlink_not_found(mock_page_response):
             "not_in_the_page",
             match_on="href",
         )
+
+
+# load_json()
+
+
+def test_load_json_parses_what_sqlite_builds():
+    assert load_json('{"siren": "356000000", "ca": 1.5, "nom": null}') == {
+        "siren": "356000000",
+        "ca": 1.5,
+        "nom": None,
+    }
+
+
+def test_load_json_falls_back_on_the_infinity_sqlite_renders():
+    """`json_object` turns an infinite REAL into `9.0e+999`: the standard library reads
+    it as inf, orjson refuses it. One such row must not fail a whole siren range."""
+    assert load_json('{"capital_social":9.0e+999}') == {"capital_social": float("inf")}
+
+
+def test_load_json_still_raises_on_a_malformed_payload():
+    with pytest.raises(ValueError):
+        load_json('{"siren": ')
+
+
+# convert_date_format()
+
+
+@pytest.mark.parametrize(
+    "original_date_string",
+    [
+        "2026-08-31 09:44:01+00:00",
+        "2026-08-31 09:44:01+0200",
+        "2026-01-01 00:00:00-05:00",
+        "2026-12-31 23:59:59+00:00",
+    ],
+)
+def test_convert_date_format_slice_matches_the_parser(original_date_string):
+    """The fast path must return exactly what strptime/strftime returned, offset
+    dropped rather than applied."""
+    expected = datetime.strptime(original_date_string, "%Y-%m-%d %H:%M:%S%z").strftime(
+        "%Y-%m-%dT%H:%M:%S"
+    )
+
+    assert convert_date_format(original_date_string) == expected
+
+
+@pytest.mark.parametrize(
+    "original_date_string, expected",
+    [
+        (None, None),
+        ("2026-08-31", None),
+        ("2026-08-31 09:44:01", None),
+        ("2026-08-31 09:44:01.123+00:00", None),
+        ("pas une date", None),
+    ],
+)
+def test_convert_date_format_rejects_what_it_always_rejected(
+    original_date_string, expected
+):
+    assert convert_date_format(original_date_string) == expected

--- a/workflows/data_pipelines/elasticsearch/dag_index_data.py
+++ b/workflows/data_pipelines/elasticsearch/dag_index_data.py
@@ -29,11 +29,14 @@ from data_pipelines_annuaire.helpers.flush_cache import flush_redis_cache
 from data_pipelines_annuaire.tests.e2e_tests.run_tests import run_e2e_tests
 from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.task_functions.index import (
     check_elastic_index,
+    compute_siren_shards,
     create_elastic_index,
     delete_previous_elastic_indices,
     fill_elastic_fondation_index,
     fill_elastic_siren_index,
     get_next_index_name,
+    prepare_elastic_index_for_bulk,
+    restore_elastic_index_settings,
     update_elastic_alias,
 )
 from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.task_functions.sitemap import (
@@ -77,16 +80,30 @@ def index_elasticsearch():
             f"{AIRFLOW_ELK_DATA_DIR}sirene.db",
         )
 
-    elastic_alias_updated = (
+    index_prepared = (
         get_next_index_name()
         >> clean_folder()
         >> get_latest_sirene_database()
         >> delete_previous_elastic_indices()
         >> create_elastic_index()
-        >> fill_elastic_siren_index()
-        >> fill_elastic_fondation_index()
-        >> check_elastic_index()
-        >> update_elastic_alias()
+        >> prepare_elastic_index_for_bulk()
+    )
+
+    siren_shards = compute_siren_shards()
+    siren_index_filled = fill_elastic_siren_index.expand(siren_range=siren_shards)
+    index_prepared >> siren_shards
+
+    # The settings are restored whatever the shards did (ALL_DONE), and everything
+    # downstream waits for that restore *and* for the shards themselves, so a failed
+    # shard still stops the pipeline instead of being masked by a successful restore.
+    settings_restored = restore_elastic_index_settings()
+    siren_index_filled >> settings_restored
+
+    fondations_filled = fill_elastic_fondation_index()
+    [siren_index_filled, settings_restored] >> fondations_filled
+
+    elastic_alias_updated = (
+        fondations_filled >> check_elastic_index() >> update_elastic_alias()
     )
 
     sitemap_updated = elastic_alias_updated >> create_sitemap() >> update_sitemap()

--- a/workflows/data_pipelines/elasticsearch/data_enrichment.py
+++ b/workflows/data_pipelines/elasticsearch/data_enrichment.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 from slugify import slugify
@@ -7,6 +6,7 @@ from data_pipelines_annuaire.helpers.utils import (
     drop_exact_duplicates,
     get_empty_string_if_none,
     load_file,
+    load_json,
     sqlite_str_to_bool,
     str_to_bool,
     str_to_list,
@@ -418,7 +418,7 @@ def format_personnes_physiques(
 ):
     if list_all_personnes is None:
         list_all_personnes = []
-    personnes_physiques = json.loads(list_personnes_physiques_sqlite)
+    personnes_physiques = load_json(list_personnes_physiques_sqlite)
     personnes_physiques_processed = []
 
     for personne_physique in personnes_physiques:
@@ -482,7 +482,7 @@ def format_personnes_physiques(
 def format_dirigeants_pm(list_dirigeants_pm_sqlite, list_all_dirigeants=None):
     if list_all_dirigeants is None:
         list_all_dirigeants = []
-    dirigeants_pm = json.loads(list_dirigeants_pm_sqlite)
+    dirigeants_pm = load_json(list_dirigeants_pm_sqlite)
     dirigeants_pm_processed = []
     for dirigeant_pm in dirigeants_pm:
         if dirigeant_pm["denomination"]:
@@ -515,7 +515,7 @@ def format_dirigeants_pm(list_dirigeants_pm_sqlite, list_all_dirigeants=None):
 
 
 def format_bodacc(bodacc_sqlite):
-    bodacc = json.loads(bodacc_sqlite) if bodacc_sqlite else {}
+    bodacc = load_json(bodacc_sqlite) if bodacc_sqlite else {}
     if bodacc.get("radiation"):
         bodacc["radiation"]["est_radie"] = sqlite_str_to_bool(
             bodacc["radiation"].get("est_radie", None)
@@ -539,7 +539,7 @@ def format_etablissements_and_complements(
     sigle,
     is_non_diffusible=False,
 ):
-    etablissements = json.loads(list_etablissements_sqlite)
+    etablissements = load_json(list_etablissements_sqlite)
     etablissements_processed = []
     complements = {
         "est_uai": False,
@@ -629,7 +629,7 @@ def format_etablissements_and_complements(
 def format_siege_unite_legale(siege, is_non_diffusible=False):
     if not siege:
         return None
-    siege = json.loads(siege)
+    siege = load_json(siege)
     siege["adresse"] = format_adresse_complete(
         siege["complement_adresse"],
         siege["numero_voie"],

--- a/workflows/data_pipelines/elasticsearch/indexing_unite_legale.py
+++ b/workflows/data_pipelines/elasticsearch/indexing_unite_legale.py
@@ -1,8 +1,12 @@
+import cProfile
+import io
 import logging
+import pstats
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 
+from elastic_transport import OrjsonSerializer
 from elasticsearch.helpers import expand_action, parallel_bulk
 
 from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.mapping_index import (
@@ -15,6 +19,10 @@ from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch\
 
 # fmt: on
 logger = logging.getLogger(__name__)
+
+# TEMPORARY, to be removed once the transform has been profiled: number of unites
+# legales to profile at the start of the task, 0 to disable.
+PROFILE_TRANSFORM_UNITES_LEGALES = 50_000
 
 LOG_EVERY_N_DOCUMENTS = 1_000_000
 MAX_LOGGED_FAILURES = 20
@@ -54,7 +62,7 @@ class ProducerTimings:
 
 
 class TimedJsonSerializer:
-    """Wraps the JSON serializer of the client to measure the document encoding.
+    """Wraps a JSON serializer to measure the document encoding it does.
 
     `parallel_bulk` chunks its actions through `_chunk_actions`, which calls
     `serializer.dumps` twice per document (the action header, then the source) in the
@@ -91,18 +99,25 @@ def timed_expand_action(timings):
 
 
 @contextmanager
-def time_bulk_encoding(elastic_connection, timings):
-    """Install the timing serializer for the duration of the bulk indexing.
+def orjson_bulk_serializer(elastic_connection, timings):
+    """Encode the bulk payloads with orjson, and keep measuring the cost.
 
     `parallel_bulk` resolves its serializer through
     `client.transport.serializers.get_serializer("application/json")`, so replacing
-    that entry is enough to observe the encoding. It is also the seam to reuse to swap
-    in a faster JSON implementation if the measure says the encoding is worth it.
+    that entry swaps the implementation for the whole bulk. The 2026-08-31 run spent
+    1690s of its 8688s encoding documents with the standard library; orjson measured
+    ~7x faster on documents of this shape. `OrjsonSerializer` subclasses
+    `JsonSerializer` and only overrides `json_dumps` / `json_loads`, so the `default`
+    hook (date, UUID, Decimal) is unchanged.
+
+    The swap is scoped to the indexing: the connection is a process-wide singleton and
+    nothing else in the DAG needs it. The timing wrapper stays on top so the gain shows
+    up in the logs instead of being assumed.
     """
     serializers = elastic_connection.transport.serializers
     original_serializer = serializers.get_serializer(JSON_MIMETYPE)
     serializers.serializers[JSON_MIMETYPE] = TimedJsonSerializer(
-        original_serializer, timings
+        OrjsonSerializer(), timings
     )
     try:
         yield
@@ -152,6 +167,18 @@ def doc_unite_legale_generator(data, elastic_index):
             ).to_dict(include_meta=True)
 
 
+def log_transform_profile(profiler, unites_legales_read):
+    stats_stream = io.StringIO()
+    statistics = pstats.Stats(profiler, stream=stats_stream)
+    statistics.sort_stats("cumulative").print_stats(30)
+    statistics.sort_stats("tottime").print_stats(30)
+    logger.info(
+        f"Transform profile over the first {unites_legales_read} unites legales. "
+        f"The transform timings of that window are inflated by the profiler, the rest "
+        f"of the run is unaffected.\n{stats_stream.getvalue()}"
+    )
+
+
 def generate_unite_legale_docs(cursor, elastic_bulk_size, elastic_index, timings):
     # Lazily stream documents to index: pull a batch from SQLite, clean it,
     # and yield each resulting document. Feeding a single long-lived generator to
@@ -161,6 +188,9 @@ def generate_unite_legale_docs(cursor, elastic_bulk_size, elastic_index, timings
     # Each phase is materialised rather than chained lazily so that its cost can be
     # measured separately, see ProducerTimings.
     unite_legale_columns = tuple(x[0] for x in cursor.description)
+    # `transform` is the largest phase of the run and calls ~40 helpers per unite
+    # legale, so it needs a profile rather than a guess. Over the first chunks only.
+    profiler = cProfile.Profile() if PROFILE_TRANSFORM_UNITES_LEGALES else None
     while True:
         started_at = time.perf_counter()
         chunk_unites_legales_sqlite = cursor.fetchmany(elastic_bulk_size)
@@ -170,6 +200,8 @@ def generate_unite_legale_docs(cursor, elastic_bulk_size, elastic_index, timings
             return
 
         started_at = time.perf_counter()
+        if profiler:
+            profiler.enable()
         liste_unites_legales_sqlite = tuple(
             dict(zip(unite_legale_columns, unite_legale))
             for unite_legale in chunk_unites_legales_sqlite
@@ -177,6 +209,8 @@ def generate_unite_legale_docs(cursor, elastic_bulk_size, elastic_index, timings
         chunk_unites_legales_processed = process_unites_legales(
             liste_unites_legales_sqlite
         )
+        if profiler:
+            profiler.disable()
         timings.transform += time.perf_counter() - started_at
 
         started_at = time.perf_counter()
@@ -186,6 +220,11 @@ def generate_unite_legale_docs(cursor, elastic_bulk_size, elastic_index, timings
         timings.build_documents += time.perf_counter() - started_at
 
         timings.unites_legales_read += len(chunk_unites_legales_sqlite)
+
+        if profiler and timings.unites_legales_read >= PROFILE_TRANSFORM_UNITES_LEGALES:
+            log_transform_profile(profiler, timings.unites_legales_read)
+            profiler = None
+
         yield from documents
 
 
@@ -212,57 +251,46 @@ def index_unites_legales_by_chunk(
     elastic_bulk_size,
     elastic_index,
 ):
-    # Indexing performance : do not refresh the index while indexing
-    elastic_connection.indices.put_settings(
-        index=elastic_index,
-        body={
-            "index.refresh_interval": -1,
-            "index.translog.durability": "async",
-        },
-    )
+    """Index the documents the cursor yields, and return how many were indexed.
 
+    The index settings (`refresh_interval`, `translog.durability`) are handled by the
+    tasks surrounding this one: the function is called once per siren shard, so it can
+    neither disable refresh on entry nor restore it on exit without fighting the other
+    shards.
+    """
     timings = ProducerTimings()
     started_at = time.perf_counter()
     doc_count = 0
     failure_count = 0
     next_log_at = LOG_EVERY_N_DOCUMENTS
-    try:
-        # A single parallel_bulk call over one long-lived generator keeps all
-        # `elastic_bulk_thread_count` threads saturated while the generator reads
-        # ahead from SQLite, overlapping read/transform with the ES bulk requests.
-        # raise_on_* are disabled so that a failed document does not abort the whole
-        # stream: failures are counted and the task fails at the end instead, which
-        # tells us how many documents are missing rather than losing them silently.
-        with time_bulk_encoding(elastic_connection, timings):
-            for success, details in parallel_bulk(
-                elastic_connection,
-                generate_unite_legale_docs(
-                    cursor, elastic_bulk_size, elastic_index, timings
-                ),
-                thread_count=elastic_bulk_thread_count,
-                chunk_size=elastic_bulk_size,
-                expand_action_callback=timed_expand_action(timings),
-                raise_on_exception=False,
-                raise_on_error=False,
-            ):
-                if success:
-                    doc_count += 1
-                    if doc_count >= next_log_at:
-                        log_indexing_progress(doc_count, started_at, timings)
-                        next_log_at += LOG_EVERY_N_DOCUMENTS
-                else:
-                    failure_count += 1
-                    if failure_count <= MAX_LOGGED_FAILURES:
-                        logger.error(f"A document failed to index: {details}")
-    finally:
-        # rollback to the original values
-        elastic_connection.indices.put_settings(
-            index=elastic_index,
-            body={
-                "index.refresh_interval": None,
-                "index.translog.durability": None,
-            },
-        )
+
+    # A single parallel_bulk call over one long-lived generator keeps all
+    # `elastic_bulk_thread_count` threads saturated while the generator reads ahead
+    # from SQLite, overlapping read/transform with the ES bulk requests.
+    # raise_on_* are disabled so that a failed document does not abort the whole
+    # stream: failures are counted and the task fails at the end instead, which tells
+    # us how many documents are missing rather than losing them silently.
+    with orjson_bulk_serializer(elastic_connection, timings):
+        for success, details in parallel_bulk(
+            elastic_connection,
+            generate_unite_legale_docs(
+                cursor, elastic_bulk_size, elastic_index, timings
+            ),
+            thread_count=elastic_bulk_thread_count,
+            chunk_size=elastic_bulk_size,
+            expand_action_callback=timed_expand_action(timings),
+            raise_on_exception=False,
+            raise_on_error=False,
+        ):
+            if success:
+                doc_count += 1
+                if doc_count >= next_log_at:
+                    log_indexing_progress(doc_count, started_at, timings)
+                    next_log_at += LOG_EVERY_N_DOCUMENTS
+            else:
+                failure_count += 1
+                if failure_count <= MAX_LOGGED_FAILURES:
+                    logger.error(f"A document failed to index: {details}")
 
     log_indexing_progress(doc_count, started_at, timings)
 
@@ -272,37 +300,5 @@ def index_unites_legales_by_chunk(
             f"({doc_count} succeeded). See the logs for the first "
             f"{MAX_LOGGED_FAILURES} failures."
         )
-
-    # Indexing performance :
-    #
-    # The _/cat/count/{index} is called only once at the end of the indexing process
-    # and not after each pushed bulk
-    #
-    # i.e. the _cat/count/{index} produce a query that may force Lucene to refresh the
-    # last bulk into a segment
-    # meaning that it would amplify the amount of segment merge and slowdown the
-    # indexing process
-
-    # Add wait and retry mechanism for zero count
-    max_retries = 5
-    retry_interval = 5  # seconds
-
-    for attempt in range(max_retries):
-        doc_count = int(
-            elastic_connection.cat.count(
-                index=elastic_index, params={"format": "json"}
-            )[0]["count"]
-        )
-
-        if doc_count > 0:
-            break
-
-        if attempt < max_retries - 1:
-            logger.warning(
-                f"Document count is zero. Retrying in {retry_interval} seconds..."
-            )
-            time.sleep(retry_interval)
-        else:
-            logger.error("Max retries reached. Document count is still zero.")
 
     return doc_count

--- a/workflows/data_pipelines/elasticsearch/indexing_unite_legale.py
+++ b/workflows/data_pipelines/elasticsearch/indexing_unite_legale.py
@@ -1,8 +1,9 @@
 import logging
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 
-from elasticsearch.helpers import parallel_bulk
+from elasticsearch.helpers import expand_action, parallel_bulk
 
 from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.mapping_index import (
     StructureMapping,
@@ -17,26 +18,96 @@ logger = logging.getLogger(__name__)
 
 LOG_EVERY_N_DOCUMENTS = 1_000_000
 MAX_LOGGED_FAILURES = 20
+JSON_MIMETYPE = "application/json"
 
 
 @dataclass
 class ProducerTimings:
     """Time spent by the producer thread, split by phase.
 
-    Only actual work is accumulated here: while the producer is blocked by the bulk
-    queue back-pressure, it sits between two `yield`s and no timer is running. So
-    comparing `busy` to the total wall clock of the indexing tells whether the
-    pipeline is producer-bound (SQLite query + Python transform) or Elasticsearch-bound.
+    `ThreadPool.imap` drains its iterable from a single task handler thread, so that
+    one thread runs everything up to the bulk queue: our generator (fetch, transform,
+    build_documents), then `expand_action` and the JSON encoding of every document
+    (see TimedJsonSerializer). All five phases are therefore on the critical path and
+    all five are accumulated here.
+
+    Only actual work is accumulated: while the producer is blocked by the bulk queue
+    back-pressure it sits inside `queue.put` and no timer is running. `wall clock -
+    busy` is thus the time spent waiting on Elasticsearch, and `busy / wall clock`
+    tells whether the pipeline is producer-bound or Elasticsearch-bound.
     """
 
     unites_legales_read: int = field(default=0)
     fetch: float = field(default=0.0)
     transform: float = field(default=0.0)
     build_documents: float = field(default=0.0)
+    expand: float = field(default=0.0)
+    serialize: float = field(default=0.0)
+
+    @property
+    def bulk_encode(self) -> float:
+        return self.expand + self.serialize
 
     @property
     def busy(self) -> float:
-        return self.fetch + self.transform + self.build_documents
+        return self.fetch + self.transform + self.build_documents + self.bulk_encode
+
+
+class TimedJsonSerializer:
+    """Wraps the JSON serializer of the client to measure the document encoding.
+
+    `parallel_bulk` chunks its actions through `_chunk_actions`, which calls
+    `serializer.dumps` twice per document (the action header, then the source) in the
+    thread that drains our generator. That encoding costs as much as any other
+    producer phase but used to be invisible, which made the remaining wall clock look
+    like Elasticsearch back-pressure when part of it was our own CPU.
+
+    Only `dumps` is timed: `loads` is called by the bulk worker threads when decoding
+    the responses, off the producer thread, and is delegated untouched.
+    """
+
+    def __init__(self, serializer, timings) -> None:
+        self._serializer = serializer
+        self._timings = timings
+
+    def __getattr__(self, name):
+        return getattr(self._serializer, name)
+
+    def dumps(self, data):
+        started_at = time.perf_counter()
+        serialized = self._serializer.dumps(data)
+        self._timings.serialize += time.perf_counter() - started_at
+        return serialized
+
+
+def timed_expand_action(timings):
+    def expand_and_time(action):
+        started_at = time.perf_counter()
+        expanded = expand_action(action)
+        timings.expand += time.perf_counter() - started_at
+        return expanded
+
+    return expand_and_time
+
+
+@contextmanager
+def time_bulk_encoding(elastic_connection, timings):
+    """Install the timing serializer for the duration of the bulk indexing.
+
+    `parallel_bulk` resolves its serializer through
+    `client.transport.serializers.get_serializer("application/json")`, so replacing
+    that entry is enough to observe the encoding. It is also the seam to reuse to swap
+    in a faster JSON implementation if the measure says the encoding is worth it.
+    """
+    serializers = elastic_connection.transport.serializers
+    original_serializer = serializers.get_serializer(JSON_MIMETYPE)
+    serializers.serializers[JSON_MIMETYPE] = TimedJsonSerializer(
+        original_serializer, timings
+    )
+    try:
+        yield
+    finally:
+        serializers.serializers[JSON_MIMETYPE] = original_serializer
 
 
 def doc_unite_legale_generator(data, elastic_index):
@@ -120,13 +191,17 @@ def generate_unite_legale_docs(cursor, elastic_bulk_size, elastic_index, timings
 
 def log_indexing_progress(doc_count, started_at, timings):
     elapsed = time.perf_counter() - started_at
+    waiting = elapsed - timings.busy
     logger.info(
         f"Indexed {doc_count} documents from {timings.unites_legales_read} unites "
         f"legales in {elapsed:.0f}s. Producer busy {timings.busy:.0f}s "
         f"({timings.busy / elapsed:.0%} of wall clock): "
         f"sqlite fetch {timings.fetch:.0f}s, "
         f"transform {timings.transform:.0f}s, "
-        f"document build {timings.build_documents:.0f}s"
+        f"document build {timings.build_documents:.0f}s, "
+        f"bulk encode {timings.bulk_encode:.0f}s "
+        f"(expand {timings.expand:.0f}s + json {timings.serialize:.0f}s). "
+        f"Waiting on elasticsearch {waiting:.0f}s ({waiting / elapsed:.0%})"
     )
 
 
@@ -158,25 +233,27 @@ def index_unites_legales_by_chunk(
         # raise_on_* are disabled so that a failed document does not abort the whole
         # stream: failures are counted and the task fails at the end instead, which
         # tells us how many documents are missing rather than losing them silently.
-        for success, details in parallel_bulk(
-            elastic_connection,
-            generate_unite_legale_docs(
-                cursor, elastic_bulk_size, elastic_index, timings
-            ),
-            thread_count=elastic_bulk_thread_count,
-            chunk_size=elastic_bulk_size,
-            raise_on_exception=False,
-            raise_on_error=False,
-        ):
-            if success:
-                doc_count += 1
-                if doc_count >= next_log_at:
-                    log_indexing_progress(doc_count, started_at, timings)
-                    next_log_at += LOG_EVERY_N_DOCUMENTS
-            else:
-                failure_count += 1
-                if failure_count <= MAX_LOGGED_FAILURES:
-                    logger.error(f"A document failed to index: {details}")
+        with time_bulk_encoding(elastic_connection, timings):
+            for success, details in parallel_bulk(
+                elastic_connection,
+                generate_unite_legale_docs(
+                    cursor, elastic_bulk_size, elastic_index, timings
+                ),
+                thread_count=elastic_bulk_thread_count,
+                chunk_size=elastic_bulk_size,
+                expand_action_callback=timed_expand_action(timings),
+                raise_on_exception=False,
+                raise_on_error=False,
+            ):
+                if success:
+                    doc_count += 1
+                    if doc_count >= next_log_at:
+                        log_indexing_progress(doc_count, started_at, timings)
+                        next_log_at += LOG_EVERY_N_DOCUMENTS
+                else:
+                    failure_count += 1
+                    if failure_count <= MAX_LOGGED_FAILURES:
+                        logger.error(f"A document failed to index: {details}")
     finally:
         # rollback to the original values
         elastic_connection.indices.put_settings(

--- a/workflows/data_pipelines/elasticsearch/indexing_unite_legale.py
+++ b/workflows/data_pipelines/elasticsearch/indexing_unite_legale.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from dataclasses import dataclass, field
 
 from elasticsearch.helpers import parallel_bulk
 
@@ -13,6 +14,29 @@ from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch\
 
 # fmt: on
 logger = logging.getLogger(__name__)
+
+LOG_EVERY_N_DOCUMENTS = 1_000_000
+MAX_LOGGED_FAILURES = 20
+
+
+@dataclass
+class ProducerTimings:
+    """Time spent by the producer thread, split by phase.
+
+    Only actual work is accumulated here: while the producer is blocked by the bulk
+    queue back-pressure, it sits between two `yield`s and no timer is running. So
+    comparing `busy` to the total wall clock of the indexing tells whether the
+    pipeline is producer-bound (SQLite query + Python transform) or Elasticsearch-bound.
+    """
+
+    unites_legales_read: int = field(default=0)
+    fetch: float = field(default=0.0)
+    transform: float = field(default=0.0)
+    build_documents: float = field(default=0.0)
+
+    @property
+    def busy(self) -> float:
+        return self.fetch + self.transform + self.build_documents
 
 
 def doc_unite_legale_generator(data, elastic_index):
@@ -57,6 +81,55 @@ def doc_unite_legale_generator(data, elastic_index):
             ).to_dict(include_meta=True)
 
 
+def generate_unite_legale_docs(cursor, elastic_bulk_size, elastic_index, timings):
+    # Lazily stream documents to index: pull a batch from SQLite, clean it,
+    # and yield each resulting document. Feeding a single long-lived generator to
+    # parallel_bulk lets the read/transform overlap with the ES bulk requests
+    # instead of running them serially per batch.
+    #
+    # Each phase is materialised rather than chained lazily so that its cost can be
+    # measured separately, see ProducerTimings.
+    unite_legale_columns = tuple(x[0] for x in cursor.description)
+    while True:
+        started_at = time.perf_counter()
+        chunk_unites_legales_sqlite = cursor.fetchmany(elastic_bulk_size)
+        timings.fetch += time.perf_counter() - started_at
+
+        if not chunk_unites_legales_sqlite:
+            return
+
+        started_at = time.perf_counter()
+        liste_unites_legales_sqlite = tuple(
+            dict(zip(unite_legale_columns, unite_legale))
+            for unite_legale in chunk_unites_legales_sqlite
+        )
+        chunk_unites_legales_processed = process_unites_legales(
+            liste_unites_legales_sqlite
+        )
+        timings.transform += time.perf_counter() - started_at
+
+        started_at = time.perf_counter()
+        documents = list(
+            doc_unite_legale_generator(chunk_unites_legales_processed, elastic_index)
+        )
+        timings.build_documents += time.perf_counter() - started_at
+
+        timings.unites_legales_read += len(chunk_unites_legales_sqlite)
+        yield from documents
+
+
+def log_indexing_progress(doc_count, started_at, timings):
+    elapsed = time.perf_counter() - started_at
+    logger.info(
+        f"Indexed {doc_count} documents from {timings.unites_legales_read} unites "
+        f"legales in {elapsed:.0f}s. Producer busy {timings.busy:.0f}s "
+        f"({timings.busy / elapsed:.0%} of wall clock): "
+        f"sqlite fetch {timings.fetch:.0f}s, "
+        f"transform {timings.transform:.0f}s, "
+        f"document build {timings.build_documents:.0f}s"
+    )
+
+
 def index_unites_legales_by_chunk(
     cursor,
     elastic_connection,
@@ -66,62 +139,62 @@ def index_unites_legales_by_chunk(
 ):
     # Indexing performance : do not refresh the index while indexing
     elastic_connection.indices.put_settings(
-        index=elastic_index, body={"index.refresh_interval": -1}
+        index=elastic_index,
+        body={
+            "index.refresh_interval": -1,
+            "index.translog.durability": "async",
+        },
     )
 
-    log_counter = 0
+    timings = ProducerTimings()
+    started_at = time.perf_counter()
     doc_count = 0
-    chunk_unites_legales_sqlite = cursor.fetchmany(elastic_bulk_size)
-    while chunk_unites_legales_sqlite:
-        unite_legale_columns = tuple([x[0] for x in cursor.description])
-        liste_unites_legales_sqlite = []
-        # Group all fetched unites_legales from sqlite in one list
-        for unite_legale in chunk_unites_legales_sqlite:
-            liste_unites_legales_sqlite.append(
-                {
-                    unite_legale_columns: value
-                    for unite_legale_columns, value in zip(
-                        unite_legale_columns, unite_legale
-                    )
-                }
-            )
-
-        liste_unites_legales_sqlite = tuple(liste_unites_legales_sqlite)
-
-        chunk_unites_legales_processed = process_unites_legales(
-            liste_unites_legales_sqlite
+    failure_count = 0
+    next_log_at = LOG_EVERY_N_DOCUMENTS
+    try:
+        # A single parallel_bulk call over one long-lived generator keeps all
+        # `elastic_bulk_thread_count` threads saturated while the generator reads
+        # ahead from SQLite, overlapping read/transform with the ES bulk requests.
+        # raise_on_* are disabled so that a failed document does not abort the whole
+        # stream: failures are counted and the task fails at the end instead, which
+        # tells us how many documents are missing rather than losing them silently.
+        for success, details in parallel_bulk(
+            elastic_connection,
+            generate_unite_legale_docs(
+                cursor, elastic_bulk_size, elastic_index, timings
+            ),
+            thread_count=elastic_bulk_thread_count,
+            chunk_size=elastic_bulk_size,
+            raise_on_exception=False,
+            raise_on_error=False,
+        ):
+            if success:
+                doc_count += 1
+                if doc_count >= next_log_at:
+                    log_indexing_progress(doc_count, started_at, timings)
+                    next_log_at += LOG_EVERY_N_DOCUMENTS
+            else:
+                failure_count += 1
+                if failure_count <= MAX_LOGGED_FAILURES:
+                    logger.error(f"A document failed to index: {details}")
+    finally:
+        # rollback to the original values
+        elastic_connection.indices.put_settings(
+            index=elastic_index,
+            body={
+                "index.refresh_interval": None,
+                "index.translog.durability": None,
+            },
         )
-        log_counter += 1
-        if log_counter % 100000 == 0:
-            logger.info(f"log_counter={log_counter}")
-        try:
-            chunk_doc_generator = doc_unite_legale_generator(
-                chunk_unites_legales_processed, elastic_index
-            )
-            # Bulk index documents into elasticsearch using the parallel version of the
-            # bulk helper that runs in multiple threads
-            # The bulk helper accept an instance of Elasticsearch class and an
-            # iterable, a generator in our case
-            for success, details in parallel_bulk(
-                elastic_connection,
-                chunk_doc_generator,
-                thread_count=elastic_bulk_thread_count,
-                chunk_size=elastic_bulk_size,
-            ):
-                if not success:
-                    raise Exception(f"A file_access document failed: {details}")
-                else:
-                    doc_count += 1
-        except Exception as e:
-            logger.error(f"Failed to send to Elasticsearch: {e}")
-        logger.info(f"Number of documents indexed: {doc_count}")
 
-        chunk_unites_legales_sqlite = cursor.fetchmany(elastic_bulk_size)
+    log_indexing_progress(doc_count, started_at, timings)
 
-    # rollback to the original value
-    elastic_connection.indices.put_settings(
-        index=elastic_index, body={"index.refresh_interval": None}
-    )
+    if failure_count:
+        raise Exception(
+            f"{failure_count} documents failed to index "
+            f"({doc_count} succeeded). See the logs for the first "
+            f"{MAX_LOGGED_FAILURES} failures."
+        )
 
     # Indexing performance :
     #

--- a/workflows/data_pipelines/elasticsearch/process_unites_legales.py
+++ b/workflows/data_pipelines/elasticsearch/process_unites_legales.py
@@ -1,8 +1,8 @@
-import json
 from datetime import UTC, datetime
 
 from data_pipelines_annuaire.helpers.utils import (
     convert_date_format,
+    load_json,
     sqlite_str_to_bool,
     str_to_list,
 )
@@ -36,12 +36,14 @@ from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.structure_ty
 
 def process_unites_legales(chunk_unites_legales_sqlite):
     list_unites_legales_processed = []
+    # Constant for the run, and this loop turns over 30 million times.
+    date_mise_a_jour = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S")
     for unite_legale in chunk_unites_legales_sqlite:
         unite_legale_processed = {}
         type_structure = [StructureType.UNITE_LEGALE]
         for field in unite_legale:
             if field in ["colter_elus"]:
-                unite_legale_processed[field] = json.loads(unite_legale[field])
+                unite_legale_processed[field] = load_json(unite_legale[field])
             else:
                 unite_legale_processed[field] = unite_legale[field]
         # Statut de diffusion
@@ -68,7 +70,7 @@ def process_unites_legales(chunk_unites_legales_sqlite):
 
         # Bilan financier
         if unite_legale["bilan_financier"]:
-            unite_legale_processed["bilan_financier"] = json.loads(
+            unite_legale_processed["bilan_financier"] = load_json(
                 unite_legale["bilan_financier"]
             )
         else:
@@ -129,7 +131,7 @@ def process_unites_legales(chunk_unites_legales_sqlite):
         # Immatriculation
         immatriculation = unite_legale.get("immatriculation")
         if immatriculation:
-            immatriculation_data = json.loads(immatriculation)
+            immatriculation_data = load_json(immatriculation)
             immatriculation_data["indicateur_associe_unique"] = sqlite_str_to_bool(
                 immatriculation_data.get("indicateur_associe_unique", None)
             )
@@ -263,10 +265,7 @@ def process_unites_legales(chunk_unites_legales_sqlite):
             unite_legale["from_rne"]
         )
 
-        # Get the current date and time
-        unite_legale_processed["date_mise_a_jour"] = datetime.now(tz=UTC).strftime(
-            "%Y-%m-%dT%H:%M:%S"
-        )
+        unite_legale_processed["date_mise_a_jour"] = date_mise_a_jour
         unite_legale_processed["date_mise_a_jour_rne"] = convert_date_format(
             unite_legale["date_mise_a_jour_rne"]
         )
@@ -307,7 +306,7 @@ def process_unites_legales(chunk_unites_legales_sqlite):
         # See the fill_elastic_fondation_index() task for fondations without a SIRET
         fondation = unite_legale_processed.pop("fondation")
         if fondation:
-            fondation = json.loads(fondation)
+            fondation = load_json(fondation)
             fondation["adresse"] = format_fondation_adresse(fondation)
             unite_legale_processed["numero_rnf"] = fondation["numero_rnf"]
             type_structure.append(StructureType.FONDATION)

--- a/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
+++ b/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
@@ -1,4 +1,4 @@
-select_fields_to_index_query = """SELECT
+SELECT_FIELDS_TO_INDEX_QUERY = """SELECT
             ul.activite_principale_unite_legale as activite_principale_unite_legale,
             ul.activite_principale_naf25_unite_legale as activite_principale_naf25_unite_legale,
             ul.caractere_employeur as caractere_employeur,
@@ -502,5 +502,28 @@ select_fields_to_index_query = """SELECT
             ON
                 ul.siren = st.siren
             WHERE ul.siren IS NOT NULL
-            ;
     """
+
+
+def select_fields_to_index_query(siren_start=None, siren_end=None):
+    """Return the query and its parameters, restricted to a range of siren.
+
+    Both bounds are optional: the first shard has no lower bound and the last no upper
+    one. The predicates are appended only for the bounds that exist rather than being
+    neutralised with `? IS NULL OR ...`, because the OR form costs the range scan —
+    EXPLAIN QUERY PLAN then falls back to walking the whole index instead of
+    `SEARCH ul USING COVERING INDEX index_unite_legale_siren (siren>? AND siren<?)`.
+
+    siren is fixed-width TEXT, so the lexicographic order of the unique index is the
+    numeric order and a string comparison is a correct range.
+    """
+    predicates = []
+    params = []
+    if siren_start is not None:
+        predicates.append("AND ul.siren >= ?")
+        params.append(siren_start)
+    if siren_end is not None:
+        predicates.append("AND ul.siren < ?")
+        params.append(siren_end)
+
+    return f"{SELECT_FIELDS_TO_INDEX_QUERY} {' '.join(predicates)}", params

--- a/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
+++ b/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
@@ -36,25 +36,14 @@ SELECT_FIELDS_TO_INDEX_QUERY = """SELECT
                         siren = ul.siren) as sirets_par_idcc,
             (SELECT liste_idcc_unite_legale FROM convention_collective WHERE
                         siren = ul.siren) as liste_idcc_unite_legale,
-            (SELECT count FROM count_etablissement ce WHERE ce.siren = ul.siren) as
-            nombre_etablissements,
-            (SELECT count FROM count_etablissement_ouvert ceo WHERE ceo.siren = ul.siren) as
-            nombre_etablissements_ouverts,
-            (
-                SELECT json_object(
-                    'ca', ca,
-                    'resultat_net', resultat_net,
-                    'date_cloture_exercice', date_cloture_exercice,
-                    'annee_cloture_exercice', annee_cloture_exercice
-                )
-                FROM
-                (
-                    SELECT ca, resultat_net,
-                    date_cloture_exercice, annee_cloture_exercice
-                    FROM bilan_financier
-                    WHERE siren = ul.siren
-                )
-            ) as bilan_financier,
+            ce."count" as nombre_etablissements,
+            ceo."count" as nombre_etablissements_ouverts,
+            CASE WHEN bf.siren IS NOT NULL THEN json_object(
+                'ca', bf.ca,
+                'resultat_net', bf.resultat_net,
+                'date_cloture_exercice', bf.date_cloture_exercice,
+                'annee_cloture_exercice', bf.annee_cloture_exercice
+            ) END as bilan_financier,
             (SELECT json_group_array(
                 json_object(
                     'siren', siren,
@@ -372,34 +361,21 @@ SELECT_FIELDS_TO_INDEX_QUERY = """SELECT
                         WHERE s.siren = st.siren
                     )
                 ) as siege,
-            (SELECT est_entrepreneur_spectacle FROM spectacle WHERE siren = ul.siren) as
-             est_entrepreneur_spectacle,
-            (SELECT statut_entrepreneur_spectacle FROM spectacle WHERE siren = ul.siren)
-              as statut_entrepreneur_spectacle,
-            (SELECT liste_finess_juridique FROM finess_juridique WHERE siren = ul.siren)
-              as liste_finess_juridique,
-            (SELECT egapro_renseignee FROM egapro WHERE siren = ul.siren) as
-             egapro_renseignee,
-            (SELECT bilan_ges_renseigne FROM bilan_ges WHERE siren = ul.siren) as
-             bilan_ges_renseigne,
-            (SELECT est_achats_responsables FROM achats_responsables WHERE siren = ul.siren) as
-             est_achats_responsables,
-            (SELECT est_alim_confiance FROM alim_confiance WHERE siren = ul.siren) as
-             est_alim_confiance,
-            (SELECT est_patrimoine_vivant FROM patrimoine_vivant WHERE siren = ul.siren) as
-             est_patrimoine_vivant,
-            (SELECT aide_de_minimis_renseignee FROM aides_minimis WHERE siren = ul.siren) as
-             aide_de_minimis_renseignee,
-            (SELECT aide_ademe_renseignee FROM aides_ademe WHERE siren = ul.siren) as
-             aide_ademe_renseignee,
-             (SELECT est_avocat FROM avocat WHERE siren = ul.siren) as
-             est_avocat,
-            (SELECT DISTINCT colter_code_insee FROM colter WHERE siren = ul.siren) as
-            colter_code_insee,
-            (SELECT DISTINCT colter_code FROM colter WHERE siren = ul.siren) as colter_code,
-            (SELECT DISTINCT colter_niveau FROM colter WHERE siren = ul.siren) as colter_niveau,
-            (SELECT est_ess_france FROM ess_france WHERE siren = ul.siren) as
-            est_ess_france,
+            sp.est_entrepreneur_spectacle as est_entrepreneur_spectacle,
+            sp.statut_entrepreneur_spectacle as statut_entrepreneur_spectacle,
+            fj.liste_finess_juridique as liste_finess_juridique,
+            eg.egapro_renseignee as egapro_renseignee,
+            bg.bilan_ges_renseigne as bilan_ges_renseigne,
+            ar.est_achats_responsables as est_achats_responsables,
+            ac.est_alim_confiance as est_alim_confiance,
+            pv.est_patrimoine_vivant as est_patrimoine_vivant,
+            amin.aide_de_minimis_renseignee as aide_de_minimis_renseignee,
+            aade.aide_ademe_renseignee as aide_ademe_renseignee,
+            av.est_avocat as est_avocat,
+            col.colter_code_insee as colter_code_insee,
+            col.colter_code as colter_code,
+            col.colter_niveau as colter_niveau,
+            ef.est_ess_france as est_ess_france,
             (SELECT json_group_array(
                 json_object(
                     'siren', siren,
@@ -417,35 +393,22 @@ SELECT_FIELDS_TO_INDEX_QUERY = """SELECT
                     WHERE siren = ul.siren
                 )
             ) as colter_elus,
-            (SELECT est_qualiopi FROM organisme_formation WHERE siren = ul.siren) as
-            est_qualiopi,
-            (SELECT liste_id_organisme_formation FROM organisme_formation
-            WHERE siren = ul.siren)  as liste_id_organisme_formation,
-            (SELECT est_siae  FROM marche_inclusion WHERE siren = ul.siren) AS est_siae,
-            (SELECT type_siae FROM marche_inclusion WHERE siren = ul.siren)
-            AS type_siae,
-            (SELECT liste_tva FROM tva WHERE siren = ul.siren)
-              as liste_tva,
-            (
-                SELECT json_object(
-                    'numero_rnf', numero_rnf,
-                    'denomination', denomination,
-                    'type_organisme', type_organisme,
-                    'date_creation', date_creation,
-                    'siren', siren,
-                    'siret', siret,
-                    'adresse', adresse,
-                    'code_postal', code_postal,
-                    'ville', ville
-                )
-                FROM
-                (
-                    SELECT numero_rnf, denomination, type_organisme, date_creation, siren,
-                    siret, adresse, code_postal, ville
-                    FROM fondation
-                    WHERE siren = ul.siren
-                )
-            ) as fondation,
+            orgf.est_qualiopi as est_qualiopi,
+            orgf.liste_id_organisme_formation as liste_id_organisme_formation,
+            mi.est_siae AS est_siae,
+            mi.type_siae AS type_siae,
+            tva.liste_tva as liste_tva,
+            CASE WHEN fo.siren IS NOT NULL THEN json_object(
+                'numero_rnf', fo.numero_rnf,
+                'denomination', fo.denomination,
+                'type_organisme', fo.type_organisme,
+                'date_creation', fo.date_creation,
+                'siren', fo.siren,
+                'siret', fo.siret,
+                'adresse', fo.adresse,
+                'code_postal', fo.code_postal,
+                'ville', fo.ville
+            ) END as fondation,
             (
                 SELECT json_object(
                     'date_immatriculation', date_immatriculation,
@@ -470,37 +433,48 @@ SELECT_FIELDS_TO_INDEX_QUERY = """SELECT
                     WHERE siren = ul.siren
                 )
             ) as immatriculation,
-            (
-                SELECT json_object(
-                    'radiation',
-                        (
-                            SELECT case when r.visibility then
-                                json_object(
-                                    'est_radie', r.est_radie,
-                                    'id_annonce', r.id_annonce,
-                                    'date', r.date
-                                ) end
-                            FROM bodacc_radiations AS r
-                            WHERE r.siren = ul.siren
-                        ),
-                    'procedure_collective',
-                        (
-                            SELECT json_object(
-                                'statut', pc.statut,
-                                'id_annonce', pc.id_annonce,
-                                'date', pc.date
-                            )
-                            FROM bodacc_procedures_collectives AS pc
-                            WHERE pc.siren = ul.siren
-                            )
-                )
+            json_object(
+                'radiation',
+                    CASE WHEN r.siren IS NOT NULL AND r.visibility THEN json_object(
+                        'est_radie', r.est_radie,
+                        'id_annonce', r.id_annonce,
+                        'date', r.date
+                    ) END,
+                'procedure_collective',
+                    CASE WHEN pc.siren IS NOT NULL THEN json_object(
+                        'statut', pc.statut,
+                        'id_annonce', pc.id_annonce,
+                        'date', pc.date
+                    ) END
             ) as bodacc
             FROM
                 unite_legale ul
-            LEFT JOIN
-                siege st
-            ON
-                ul.siren = st.siren
+            LEFT JOIN siege st ON ul.siren = st.siren
+            -- One indexed seek per table instead of one per column, and measurably
+            -- cheaper than the correlated subqueries these replace. Only tables
+            -- verified unique on siren are joined: convention_collective (several rows
+            -- per siren) and immatriculation (duplicates) stay scalar subqueries above.
+            LEFT JOIN count_etablissement ce ON ce.siren = ul.siren
+            LEFT JOIN count_etablissement_ouvert ceo ON ceo.siren = ul.siren
+            LEFT JOIN bilan_financier bf ON bf.siren = ul.siren
+            LEFT JOIN spectacle sp ON sp.siren = ul.siren
+            LEFT JOIN finess_juridique fj ON fj.siren = ul.siren
+            LEFT JOIN egapro eg ON eg.siren = ul.siren
+            LEFT JOIN bilan_ges bg ON bg.siren = ul.siren
+            LEFT JOIN achats_responsables ar ON ar.siren = ul.siren
+            LEFT JOIN alim_confiance ac ON ac.siren = ul.siren
+            LEFT JOIN patrimoine_vivant pv ON pv.siren = ul.siren
+            LEFT JOIN aides_minimis amin ON amin.siren = ul.siren
+            LEFT JOIN aides_ademe aade ON aade.siren = ul.siren
+            LEFT JOIN avocat av ON av.siren = ul.siren
+            LEFT JOIN colter col ON col.siren = ul.siren
+            LEFT JOIN ess_france ef ON ef.siren = ul.siren
+            LEFT JOIN organisme_formation orgf ON orgf.siren = ul.siren
+            LEFT JOIN marche_inclusion mi ON mi.siren = ul.siren
+            LEFT JOIN tva ON tva.siren = ul.siren
+            LEFT JOIN fondation fo ON fo.siren = ul.siren
+            LEFT JOIN bodacc_radiations r ON r.siren = ul.siren
+            LEFT JOIN bodacc_procedures_collectives pc ON pc.siren = ul.siren
             WHERE ul.siren IS NOT NULL
     """
 

--- a/workflows/data_pipelines/elasticsearch/task_functions/index.py
+++ b/workflows/data_pipelines/elasticsearch/task_functions/index.py
@@ -63,7 +63,13 @@ def create_elastic_index():
 def fill_elastic_siren_index():
     ti = get_current_context()["ti"]
     elastic_index = ti.xcom_pull(key="elastic_index", task_ids="get_next_index_name")
-    sqlite_client = SqliteClient(AIRFLOW_ELK_DATA_DIR + "sirene.db")
+    # parallel_bulk drains the document generator (which reads from this cursor) in its
+    # own thread pool task handler, so the connection must allow cross-thread use.
+    # Access stays sequential: the query is issued here, the cursor is drained by that
+    # single handler thread, and the connection is closed here once bulk indexing is over.
+    sqlite_client = SqliteClient(
+        AIRFLOW_ELK_DATA_DIR + "sirene.db", check_same_thread=False
+    )
     sqlite_client.execute(select_fields_to_index_query)
 
     connections.create_connection(

--- a/workflows/data_pipelines/elasticsearch/task_functions/index.py
+++ b/workflows/data_pipelines/elasticsearch/task_functions/index.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from itertools import pairwise
 
 from airflow.sdk import get_current_context, task
-from airflow.utils.trigger_rule import TriggerRule
+from airflow.task.trigger_rule import TriggerRule
 from elasticsearch import NotFoundError
 from elasticsearch.dsl import connections
 
@@ -12,12 +12,13 @@ from data_pipelines_annuaire.config import (
     AIRFLOW_ELK_DATA_DIR,
     ELASTIC_BULK_SIZE,
     ELASTIC_BULK_THREAD_COUNT,
-    ELASTIC_INDEXING_SHARD_COUNT,
     ELASTIC_MAX_LIVE_VERSIONS,
     ELASTIC_MIN_DOC_COUNT_EXPECTED,
     ELASTIC_PASSWORD,
+    ELASTIC_REQUEST_TIMEOUT,
     ELASTIC_URL,
     ELASTIC_USER,
+    INDEXING_SIREN_RANGES,
 )
 from data_pipelines_annuaire.helpers import Notification
 from data_pipelines_annuaire.helpers.sqlite_client import SqliteClient
@@ -48,6 +49,7 @@ def get_elastic_connection():
         hosts=[ELASTIC_URL],
         basic_auth=(ELASTIC_USER, ELASTIC_PASSWORD),
         retry_on_timeout=True,
+        request_timeout=ELASTIC_REQUEST_TIMEOUT,
     )
     return connections.get_connection()
 
@@ -151,7 +153,7 @@ def compute_siren_shards():
     sqlite_client = SqliteClient(AIRFLOW_ELK_DATA_DIR + "sirene.db")
     sqlite_client.tune_for_large_scan()
     unites_legales_count, siren_ranges = compute_siren_ranges(
-        sqlite_client, ELASTIC_INDEXING_SHARD_COUNT
+        sqlite_client, INDEXING_SIREN_RANGES
     )
     sqlite_client.commit_and_close_conn()
 

--- a/workflows/data_pipelines/elasticsearch/task_functions/index.py
+++ b/workflows/data_pipelines/elasticsearch/task_functions/index.py
@@ -1,7 +1,10 @@
 import logging
+import time
 from datetime import UTC, datetime
+from itertools import pairwise
 
 from airflow.sdk import get_current_context, task
+from airflow.utils.trigger_rule import TriggerRule
 from elasticsearch import NotFoundError
 from elasticsearch.dsl import connections
 
@@ -9,6 +12,7 @@ from data_pipelines_annuaire.config import (
     AIRFLOW_ELK_DATA_DIR,
     ELASTIC_BULK_SIZE,
     ELASTIC_BULK_THREAD_COUNT,
+    ELASTIC_INDEXING_SHARD_COUNT,
     ELASTIC_MAX_LIVE_VERSIONS,
     ELASTIC_MIN_DOC_COUNT_EXPECTED,
     ELASTIC_PASSWORD,
@@ -35,6 +39,18 @@ from data_pipelines_annuaire.workflows.data_pipelines.elasticsearch.sqlite.fonda
 
 logger = logging.getLogger(__name__)
 
+ELASTIC_COUNT_MAX_RETRIES = 5
+ELASTIC_COUNT_RETRY_INTERVAL = 5
+
+
+def get_elastic_connection():
+    connections.create_connection(
+        hosts=[ELASTIC_URL],
+        basic_auth=(ELASTIC_USER, ELASTIC_PASSWORD),
+        retry_on_timeout=True,
+    )
+    return connections.get_connection()
+
 
 @task
 def get_next_index_name():
@@ -60,7 +76,94 @@ def create_elastic_index():
 
 
 @task
-def fill_elastic_siren_index():
+def prepare_elastic_index_for_bulk():
+    """Turn off the work Elasticsearch does between bulks, for the whole indexing.
+
+    Cannot live inside `fill_elastic_siren_index` any more: that task now runs once per
+    siren shard, and the first shard to finish would restore the settings under the
+    others.
+    """
+    ti = get_current_context()["ti"]
+    elastic_index = ti.xcom_pull(key="elastic_index", task_ids="get_next_index_name")
+    get_elastic_connection().indices.put_settings(
+        index=elastic_index,
+        body={
+            "index.refresh_interval": -1,
+            "index.translog.durability": "async",
+        },
+    )
+
+
+@task(trigger_rule=TriggerRule.ALL_DONE)
+def restore_elastic_index_settings():
+    """Put the index back the way the API expects it, whatever the shards did.
+
+    ALL_DONE, so a failed shard cannot leave the index with refresh disabled. It is a
+    leaf: the failure still propagates through the shards themselves, which
+    `fill_elastic_fondation_index` waits on.
+    """
+    ti = get_current_context()["ti"]
+    elastic_index = ti.xcom_pull(key="elastic_index", task_ids="get_next_index_name")
+    elastic_connection = get_elastic_connection()
+    elastic_connection.indices.put_settings(
+        index=elastic_index,
+        body={
+            "index.refresh_interval": None,
+            "index.translog.durability": None,
+        },
+    )
+    # One explicit refresh so that the document count read downstream is exact.
+    elastic_connection.indices.refresh(index=elastic_index)
+
+
+def compute_siren_ranges(sqlite_client, shard_count):
+    """Split the unites legales into `shard_count` contiguous ranges of siren.
+
+    Balanced by row count rather than by siren prefix: siren are handed out
+    sequentially, so a fixed split of the 9-digit space would leave some shards several
+    times larger than others, and the slowest shard sets the wall clock. Reading a
+    boundary walks the unique index on siren, no table access.
+
+    The ranges tile the whole table: the first has no lower bound, the last no upper
+    one, and each bound is shared with its neighbour. A boundary that repeats (fewer
+    rows than shards) is dropped rather than producing an empty duplicate range.
+    """
+    unites_legales_count = sqlite_client.get_table_count("unite_legale")
+
+    boundaries = []
+    for shard in range(1, shard_count):
+        offset = shard * unites_legales_count // shard_count
+        boundary = sqlite_client.execute(
+            "SELECT siren FROM unite_legale ORDER BY siren LIMIT 1 OFFSET ?",
+            (offset,),
+        ).fetchone()
+        if boundary and boundary[0] not in boundaries:
+            boundaries.append(boundary[0])
+
+    limits = [None, *boundaries, None]
+    return unites_legales_count, [
+        {"siren_start": start, "siren_end": end} for start, end in pairwise(limits)
+    ]
+
+
+@task
+def compute_siren_shards():
+    sqlite_client = SqliteClient(AIRFLOW_ELK_DATA_DIR + "sirene.db")
+    sqlite_client.tune_for_large_scan()
+    unites_legales_count, siren_ranges = compute_siren_ranges(
+        sqlite_client, ELASTIC_INDEXING_SHARD_COUNT
+    )
+    sqlite_client.commit_and_close_conn()
+
+    logger.info(
+        f"Indexing {unites_legales_count} unites legales in "
+        f"{len(siren_ranges)} shards: {siren_ranges}"
+    )
+    return siren_ranges
+
+
+@task
+def fill_elastic_siren_index(siren_range):
     ti = get_current_context()["ti"]
     elastic_index = ti.xcom_pull(key="elastic_index", task_ids="get_next_index_name")
     # parallel_bulk drains the document generator (which reads from this cursor) in its
@@ -70,24 +173,19 @@ def fill_elastic_siren_index():
     sqlite_client = SqliteClient(
         AIRFLOW_ELK_DATA_DIR + "sirene.db", check_same_thread=False
     )
-    sqlite_client.execute(select_fields_to_index_query)
-
-    connections.create_connection(
-        hosts=[ELASTIC_URL],
-        basic_auth=(ELASTIC_USER, ELASTIC_PASSWORD),
-        retry_on_timeout=True,
-    )
-    elastic_connection = connections.get_connection()
+    sqlite_client.tune_for_large_scan()
+    query, params = select_fields_to_index_query(**siren_range)
+    sqlite_client.execute(query, params)
 
     doc_count = index_unites_legales_by_chunk(
         cursor=sqlite_client.db_cursor,
-        elastic_connection=elastic_connection,
+        elastic_connection=get_elastic_connection(),
         elastic_bulk_thread_count=ELASTIC_BULK_THREAD_COUNT,
         elastic_bulk_size=ELASTIC_BULK_SIZE,
         elastic_index=elastic_index,
     )
-    ti.xcom_push(key="doc_count", value=doc_count)
     sqlite_client.commit_and_close_conn()
+    return doc_count
 
 
 @task
@@ -119,13 +217,50 @@ def fill_elastic_fondation_index():
     sqlite_client.commit_and_close_conn()
 
 
+def count_indexed_documents(elastic_connection, elastic_index):
+    """Ask Elasticsearch how many documents the index holds.
+
+    Called once, here, rather than at the end of each indexing task: `_cat/count` can
+    force Lucene to refresh the last bulk into a segment, which amplifies segment
+    merging and slows the indexing down. The retry absorbs the lag between the refresh
+    and the count being visible.
+    """
+    for attempt in range(ELASTIC_COUNT_MAX_RETRIES):
+        doc_count = int(
+            elastic_connection.cat.count(
+                index=elastic_index, params={"format": "json"}
+            )[0]["count"]
+        )
+        if doc_count > 0:
+            return doc_count
+
+        if attempt < ELASTIC_COUNT_MAX_RETRIES - 1:
+            logger.warning(
+                f"Document count is zero. Retrying in "
+                f"{ELASTIC_COUNT_RETRY_INTERVAL} seconds..."
+            )
+            time.sleep(ELASTIC_COUNT_RETRY_INTERVAL)
+
+    logger.error("Max retries reached. Document count is still zero.")
+    return 0
+
+
 @task
 def check_elastic_index():
     ti = get_current_context()["ti"]
-    doc_count = ti.xcom_pull(key="doc_count", task_ids="fill_elastic_siren_index")
+    elastic_index = ti.xcom_pull(key="elastic_index", task_ids="get_next_index_name")
+    # One value per siren shard, since fill_elastic_siren_index is a mapped task.
+    shard_doc_counts = ti.xcom_pull(task_ids="fill_elastic_siren_index") or []
     fondation_doc_count = ti.xcom_pull(
         key="fondation_doc_count",
         task_ids="fill_elastic_fondation_index",
+    )
+    doc_count = count_indexed_documents(get_elastic_connection(), elastic_index)
+    # Informational only, and read from a mapped task: never let its shape fail a run
+    # whose documents are already indexed.
+    logger.info(
+        f"Documents indexed per siren shard: {shard_doc_counts}, "
+        f"counted in the index: {doc_count}"
     )
 
     if int(doc_count) < ELASTIC_MIN_DOC_COUNT_EXPECTED:


### PR DESCRIPTION
WIP

Le DAG d'indexation (hors Snapshot) passe de 3h à 1h.

* Parallélise l'indexation avec 4 tasks au lieu d'une seule. Chaque task traite un chunk de SIREN de part à peu près égale en même temps.
* La requête SQL pour l'indexation est optimisée en privilégiant les LEFT JOIN par rapport aux EXISTS
* Utilise `orjson` comme dans `search-api` au lieu de la librairie `json` native bien moins performante

Notes : 
* Tentatives de changer les PRAGMA de Sqlite n'a pas eu d'impact notable
* Tentative de paralléliser avec 8 tasks au lieu de 4 a donné de moins bons résultats