### PR TITLE
feat(doublons): add doublons to index

### DIFF
--- a/workflows/data_pipelines/elasticsearch/mapping_index.py
+++ b/workflows/data_pipelines/elasticsearch/mapping_index.py
@@ -391,6 +391,7 @@ class UniteLegaleMapping(InnerDoc):
     siege = Object(SiegeMapping)
     sigle = Text(analyzer=annuaire_analyzer, fields={"keyword": Keyword()})
     siren = Keyword(required=True)
+    siren_pivot = Keyword()
     siret_siege = Keyword()
     sirets_par_idcc = Text()
     slug = Text()

--- a/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
+++ b/workflows/data_pipelines/elasticsearch/sqlite/fields_to_index.py
@@ -24,6 +24,7 @@ select_fields_to_index_query = """SELECT
             ul.prenom as prenom,
             ul.sigle as sigle,
             ul.siren,
+            (SELECT siren_pivot FROM doublons WHERE siren_doublon = ul.siren) as siren_pivot,
             st.siret as siret_siege,
             ul.tranche_effectif_salarie_unite_legale as
             tranche_effectif_salarie_unite_legale,

--- a/workflows/data_pipelines/etl/dag.py
+++ b/workflows/data_pipelines/etl/dag.py
@@ -59,6 +59,9 @@ from data_pipelines_annuaire.workflows.data_pipelines.etl.task_functions.create_
     create_dirig_pp_table,
     get_latest_rne_database,
 )
+from data_pipelines_annuaire.workflows.data_pipelines.etl.task_functions.create_doublons_table import (
+    create_doublons_table,
+)
 from data_pipelines_annuaire.workflows.data_pipelines.etl.task_functions.create_etablissements_tables import (
     apply_geo_stats_coordinates,
     count_nombre_etablissement,
@@ -292,6 +295,8 @@ def database_constructor():
         >> create_ancien_siege_table()
         # Liens de succession
         >> create_succession_table()
+        # Doublons SIRENE
+        >> create_doublons_table()
         # RNE
         >> get_latest_rne_database()
         >> add_rne_siren_data_to_unite_legale_table()

--- a/workflows/data_pipelines/etl/data_fetch_clean/doublons.py
+++ b/workflows/data_pipelines/etl/data_fetch_clean/doublons.py
@@ -1,0 +1,44 @@
+import logging
+import shutil
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+from data_pipelines_annuaire.config import AIRFLOW_ETL_DATA_DIR, CURRENT_MONTH
+from data_pipelines_annuaire.workflows.data_pipelines.etl.task_functions.determine_sirene_date import (
+    get_sirene_processing_month,
+)
+from data_pipelines_annuaire.workflows.data_pipelines.sirene.stock.config import (
+    STOCK_SIRENE_CONFIG,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def download_doublons():
+    year_month = get_sirene_processing_month()
+
+    filename_template = STOCK_SIRENE_CONFIG.files_to_download["doublons"][
+        "destination"
+    ].split("/")[-1]
+    filename = filename_template.replace(CURRENT_MONTH, year_month)
+
+    url = STOCK_SIRENE_CONFIG.url_object_storage + filename
+
+    data_path = Path(AIRFLOW_ETL_DATA_DIR)
+    zip_path = data_path / "StockDoublons_utf8.zip"
+
+    logger.info(f"Downloading and unpacking {url}")
+
+    with requests.get(url, allow_redirects=True, stream=True) as r:
+        r.raise_for_status()
+
+        with open(zip_path, "wb") as f_out:
+            for chunk in r.iter_content(chunk_size=1024 * 1024):
+                if chunk:
+                    f_out.write(chunk)
+
+    shutil.unpack_archive(zip_path, data_path)
+
+    return pd.read_csv(data_path / "StockDoublons_utf8.csv", dtype=str)

--- a/workflows/data_pipelines/etl/sqlite/queries/doublons.py
+++ b/workflows/data_pipelines/etl/sqlite/queries/doublons.py
@@ -1,0 +1,8 @@
+create_table_doublons_query = """
+    CREATE TABLE IF NOT EXISTS doublons
+    (
+        siren_doublon TEXT NOT NULL,
+        siren_pivot TEXT NOT NULL,
+        date_dernier_traitement_doublon DATE
+    )
+"""

--- a/workflows/data_pipelines/etl/task_functions/create_doublons_table.py
+++ b/workflows/data_pipelines/etl/task_functions/create_doublons_table.py
@@ -1,0 +1,44 @@
+import logging
+
+from airflow.sdk import get_current_context, task
+
+from data_pipelines_annuaire.workflows.data_pipelines.etl.data_fetch_clean.doublons import (
+    download_doublons,
+)
+from data_pipelines_annuaire.workflows.data_pipelines.etl.sqlite.helpers import (
+    create_table_model,
+    create_unique_index,
+    get_table_count,
+)
+from data_pipelines_annuaire.workflows.data_pipelines.etl.sqlite.queries.doublons import (
+    create_table_doublons_query,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@task
+def create_doublons_table():
+    table_name = "doublons"
+    sqlite_client = create_table_model(
+        table_name=table_name,
+        create_table_query=create_table_doublons_query,
+        create_index_func=create_unique_index,
+        index_name="index_doublons_siren_doublon",
+        index_column="siren_doublon",
+    )
+
+    df_doublons = download_doublons()
+    df_doublons.to_sql(
+        table_name, sqlite_client.db_conn, if_exists="append", index=False
+    )
+
+    ti = get_current_context()["ti"]
+    for count_doublons in sqlite_client.execute(get_table_count(table_name)):
+        logger.debug(
+            f"************ {count_doublons} total records have been added "
+            f"to the {table_name} table!"
+        )
+        ti.xcom_push(key="count_doublons", value=count_doublons)
+
+    sqlite_client.commit_and_close_conn()

--- a/workflows/data_pipelines/sirene/stock/config.py
+++ b/workflows/data_pipelines/sirene/stock/config.py
@@ -38,6 +38,11 @@ STOCK_SIRENE_CONFIG = DataSourceConfig(
             "url": "https://www.data.gouv.fr/datasets/r/9c4d5d9c-4bbb-4b9c-837a-6155cb589e26",
             "destination": f"{DataSourceConfig.base_tmp_folder}/sirene/stock/StockLiensSuccession_{CURRENT_MONTH}.zip",
         },
+        "doublons": {
+            "resource_id": "d8c31348-8630-4918-b6d1-5dd689b05f29",
+            "url": "https://www.data.gouv.fr/datasets/r/d8c31348-8630-4918-b6d1-5dd689b05f29",
+            "destination": f"{DataSourceConfig.base_tmp_folder}/sirene/stock/stock_doublons_deduplicated_{CURRENT_MONTH}.zip",
+        },
     },
     object_storage_path="insee/sirene_stock/",
     url_object_storage=f"{OBJECT_STORAGE_BASE_URL}insee/sirene_stock/",

--- a/workflows/data_pipelines/sirene/stock/dag.py
+++ b/workflows/data_pipelines/sirene/stock/dag.py
@@ -42,6 +42,10 @@ def data_processing_sirene_stock():
         return sirene_stock_processor.convert_stock_etablissement_coordinates()
 
     @task()
+    def deduplicate_doublons():
+        return sirene_stock_processor.deduplicate_stock_doublons()
+
+    @task()
     def send_file_to_object_storage():
         return sirene_stock_processor.send_stock_to_object_storage()
 
@@ -53,6 +57,7 @@ def data_processing_sirene_stock():
         clean_previous_outputs()
         >> download_stock()
         >> convert_etablissement_coordinates()
+        >> deduplicate_doublons()
         >> send_file_to_object_storage()
         >> clean_up()
     )

--- a/workflows/data_pipelines/sirene/stock/processor.py
+++ b/workflows/data_pipelines/sirene/stock/processor.py
@@ -30,6 +30,11 @@ MONTH_MAPPING = {
     "novembre": "11",
     "decembre": "12",
 }
+# Suffix to differentiate the transformed file from the original
+TRANSFORMED_FILE_SUFFIXES = {
+    "stock_etablissement": "_with_gps",
+}
+
 logger = logging.getLogger(__name__)
 
 
@@ -105,9 +110,48 @@ class SireneStockProcessor(DataProcessor):
         ) as zipf:
             # by default zip is conserving the whole directory structure (e.g. /tmp/sirene/stock..)
             # arcname allow to overwrite this
-            zipf.write(output_csv, arcname="StockEtablissement_utf8_with_gps.csv")
+            zipf.write(output_csv, arcname="StockEtablissement_utf8.csv")
 
         logger.info("Stock etablissement coordinates conversion completed.")
+
+    @staticmethod
+    def deduplicate_doublons(df_doublons: pd.DataFrame) -> pd.DataFrame:
+        """
+        In the rare case where a `siren_doublon` is linked to multiple `siren_pivot`,
+        we shall keep only the most recent. If this is not enough, we shall keep the
+        greatest `siren_pivot` as it is likely the last created.
+        """
+        return (
+            df_doublons.sort_values(
+                ["siren_doublon", "date_dernier_traitement_doublon", "siren_pivot"]
+            )
+            .drop_duplicates(subset="siren_doublon", keep="last")
+            .reset_index(drop=True)
+        )
+
+    def deduplicate_stock_doublons(self):
+        zip_path = self.config.files_to_download["doublons"]["destination"]
+        csv_filename = "StockDoublons_utf8.csv"
+        csv_path = f"{self.config.tmp_folder}{csv_filename}"
+
+        logger.info(f"Extracting {zip_path}...")
+        shutil.unpack_archive(zip_path, self.config.tmp_folder)
+
+        # The header separates the column names with ", "
+        df_doublons = pd.read_csv(csv_path, dtype=str, skipinitialspace=True).rename(
+            columns={
+                "siren": "siren_pivot",
+                "sirenDoublon": "siren_doublon",
+                "dateDernierTraitementDoublon": "date_dernier_traitement_doublon",
+            }
+        )
+        self.deduplicate_doublons(df_doublons).to_csv(csv_path, index=False)
+
+        logger.info(f"Compressing output file {csv_path} to {zip_path}...")
+        with zipfile.ZipFile(zip_path, "w") as zipf:
+            zipf.write(csv_path, arcname=csv_filename)
+
+        logger.info("Stock doublons deduplication completed.")
 
     def send_stock_to_object_storage(self):
 
@@ -116,14 +160,10 @@ class SireneStockProcessor(DataProcessor):
         for key, file_config in self.config.files_to_download.items():
             original_filename = file_config["destination"].split("/")[-1]
 
-            if key == "stock_etablissement":
-                source_name = original_filename.replace(".zip", "_with_gps.zip")
-                dest_name = self.stock_filename(source_name, file_config["resource_id"])
-            else:
-                source_name = original_filename
-                dest_name = self.stock_filename(
-                    original_filename, file_config["resource_id"]
-                )
+            source_name = original_filename.replace(
+                ".zip", f"{TRANSFORMED_FILE_SUFFIXES.get(key, '')}.zip"
+            )
+            dest_name = self.stock_filename(source_name, file_config["resource_id"])
 
             files_to_send.append(
                 File(


### PR DESCRIPTION
Closes https://github.com/annuaire-entreprises-data-gouv-fr/search-infra/issues/324

Index a new `siren_pivot` field for SIREN doublons from the SIRENE doublons dataset.

Notes : 
* `siren_pivot` = le "nouveau" siren officiel de l'entreprise
* Quelques rares siren doublons sont associés à plusieurs siren pivots. Une déduplication a lieu directement dans le DAG stock sirene afin de ne pas ralentir le DAG ETL.

Tested on dev-01 ✅ 