### PR TITLE
fix(rne.flux): add timeouts and retry backoff

### DIFF
--- a/helpers/api_client.py
+++ b/helpers/api_client.py
@@ -12,6 +12,10 @@ R = TypeVar("R", bound=Response)
 
 logger = logging.getLogger(__name__)
 
+# Requests has no default timeout
+# (connect, read) in seconds
+API_TIMEOUT = (10, 120)
+
 
 def retry_request(
     max_retries: int = 10, backoff_factor: float = 0.3
@@ -105,7 +109,7 @@ class ApiClient:
         This method is decorated with retry_request for automatic retries.
         """
         url = f"{self.base_url}{endpoint}"
-        return self.session.get(url, params=params)
+        return self.session.get(url, params=params, timeout=API_TIMEOUT)
 
     def fetch_all(
         self,

--- a/helpers/api_client.py
+++ b/helpers/api_client.py
@@ -7,6 +7,8 @@ from typing import Any, ParamSpec, TypeVar
 from airflow.sdk import Variable
 from requests import RequestException, Response, Session
 
+from data_pipelines_annuaire.helpers.retry import retry_delay
+
 P = ParamSpec("P")
 R = TypeVar("R", bound=Response)
 
@@ -46,7 +48,7 @@ def retry_request(
                             logger.info(f"Status code : {code}")
                             return response
                         case 429 | 502 | 503 | 504:
-                            sleep_time = backoff_factor * (2**retries)
+                            sleep_time = retry_delay(retries, base_delay=backoff_factor)
                             logger.warning(
                                 f"Retryable error: {response.status_code}. "
                                 f"Sleeping for {sleep_time} seconds..."

--- a/helpers/retry.py
+++ b/helpers/retry.py
@@ -1,0 +1,20 @@
+import random
+
+BASE_DELAY = 30
+MAX_DELAY = 30 * 60
+
+
+def retry_delay(
+    retry_number: int,
+    base_delay: float = BASE_DELAY,
+    max_delay: float = MAX_DELAY,
+) -> float:
+    """
+    Wait for a base delay before the first retry and then double down on each
+    additional retry up to a maximum delay. In seconds.
+
+    An API that has issues is usually down for quite some time. So increasing
+    waiting times between retries avoid to hammer it
+    """
+    delay = min(base_delay * 2**retry_number, max_delay)
+    return delay * random.uniform(0.5, 1.0)

--- a/tests/unit_tests/test_retry.py
+++ b/tests/unit_tests/test_retry.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+from data_pipelines_annuaire.helpers.retry import retry_delay
+
+
+class TestRetryDelay:
+    def test_waiting_doubles_at_every_retry(self):
+        with patch("random.uniform", return_value=1.0):
+            assert [retry_delay(n) for n in range(4)] == [30, 60, 120, 240]
+
+    def test_waiting_is_capped_at_thirty_minutes(self):
+        with patch("random.uniform", return_value=1.0):
+            assert retry_delay(20) == 30 * 60
+
+    def test_waiting_is_jittered(self):
+        with patch("random.uniform", return_value=0.5):
+            assert retry_delay(0) == 15
+
+    def test_caller_keeps_its_own_pace(self):
+        with patch("random.uniform", return_value=1.0):
+            delays = [retry_delay(n, base_delay=0.3, max_delay=10) for n in range(6)]
+
+        assert delays == [0.3, 0.6, 1.2, 2.4, 4.8, 9.6]
+
+    def test_caller_pace_is_capped_too(self):
+        with patch("random.uniform", return_value=1.0):
+            assert retry_delay(10, base_delay=0.3, max_delay=10) == 10

--- a/workflows/data_pipelines/rne/flux/dag.py
+++ b/workflows/data_pipelines/rne/flux/dag.py
@@ -21,7 +21,7 @@ default_args = {
     schedule="0 1 * * *",  # Run every day at 1 AM
     start_date=datetime(2026, 1, 1, tzinfo=UTC),
     max_active_runs=1,
-    dagrun_timeout=timedelta(days=4),
+    dagrun_timeout=timedelta(days=7),
     params={},
     catchup=False,
     on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],

--- a/workflows/data_pipelines/rne/flux/dag.py
+++ b/workflows/data_pipelines/rne/flux/dag.py
@@ -21,7 +21,7 @@ default_args = {
     schedule="0 1 * * *",  # Run every day at 1 AM
     start_date=datetime(2026, 1, 1, tzinfo=UTC),
     max_active_runs=1,
-    dagrun_timeout=timedelta(days=30),
+    dagrun_timeout=timedelta(days=4),
     params={},
     catchup=False,
     on_failure_callback=[Notification(), EmailNotification(to=EMAIL_LIST)],

--- a/workflows/data_pipelines/rne/flux/rne_api.py
+++ b/workflows/data_pipelines/rne/flux/rne_api.py
@@ -7,6 +7,7 @@ from requests.adapters import HTTPAdapter
 from requests.exceptions import SSLError
 
 from data_pipelines_annuaire.config import RNE_API_DIFF_URL, RNE_API_TOKEN_URL, RNE_AUTH
+from data_pipelines_annuaire.helpers.api_client import API_TIMEOUT
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +48,9 @@ class ApiRNEClient:
         try:
             selected_auth = random.choice(self.auth)
             logger.info(f"Authentification account used: {selected_auth['username']}")
-            response = self.session.post(RNE_API_TOKEN_URL, json=selected_auth)
+            response = self.session.post(
+                RNE_API_TOKEN_URL, json=selected_auth, timeout=API_TIMEOUT
+            )
             response.raise_for_status()
             token = response.json()["token"]
             logger.info("New token received...")
@@ -91,7 +94,7 @@ class ApiRNEClient:
                     logger.info("Getting new token...")
                     self.token = self.get_new_token()
                 headers = {"Authorization": f"Bearer {self.token}"}
-                response = self.session.get(url, headers=headers)
+                response = self.session.get(url, headers=headers, timeout=API_TIMEOUT)
                 response.raise_for_status()
                 response = response.json()
                 last_siren = self.get_last_siren_in_page(response)

--- a/workflows/data_pipelines/rne/flux/rne_api.py
+++ b/workflows/data_pipelines/rne/flux/rne_api.py
@@ -3,20 +3,23 @@ import random
 import time
 
 import requests
-from requests.adapters import HTTPAdapter
 from requests.exceptions import SSLError
 
 from data_pipelines_annuaire.config import RNE_API_DIFF_URL, RNE_API_TOKEN_URL, RNE_AUTH
 from data_pipelines_annuaire.helpers.api_client import API_TIMEOUT
+from data_pipelines_annuaire.helpers.retry import BASE_DELAY, retry_delay
 
 logger = logging.getLogger(__name__)
+
+# The RNE API quota is bound to an account, only time will lift a 429
+RATE_LIMITED_BASE_DELAY = 5 * 60
 
 
 class ApiRNEClient:
     """API client for interacting with the
     Registre National des Entreprises (RNE) API."""
 
-    def __init__(self, max_retries=100):
+    def __init__(self, max_retries=8):
         """
         Initializes the API client.
 
@@ -27,16 +30,9 @@ class ApiRNEClient:
             max_retries (int): Maximum number of retries for API requests.
         """
         self.auth = RNE_AUTH
-        self.session = self.create_persistent_session()
+        self.session = requests.Session()
         self.token = self.get_new_token()
         self.max_retries = max_retries
-
-    def create_persistent_session(self):
-        """Create a session with a custom HTTP adapter for max retries."""
-        session = requests.Session()
-        adapter = HTTPAdapter(max_retries=20)
-        session.mount("http://", adapter)
-        return session
 
     def get_new_token(self) -> str | None:
         """
@@ -86,6 +82,7 @@ class ApiRNEClient:
         if last_siren:
             url += f"&searchAfter={last_siren}"
 
+        waits = 0
         for attempt in range(self.max_retries + 1):
             if attempt > 0:
                 logger.info(f"Making API call try : {attempt}")
@@ -102,23 +99,31 @@ class ApiRNEClient:
                 return response, last_siren
 
             except Exception as e:
-                if hasattr(e, "response") and e.response.status_code in [401, 403, 429]:
+                error_response = getattr(e, "response", None)
+                status_code = getattr(error_response, "status_code", None)
+                body = getattr(error_response, "text", "") or ""
+                logger.error(
+                    f"API request failed on {url} "
+                    f"with status {status_code}: {e}. Response: {body[:500]}"
+                )
+                base_delay = BASE_DELAY
+                if status_code == 429:
+                    logger.warning("Rate limited by the RNE API.")
+                    base_delay = RATE_LIMITED_BASE_DELAY
+                elif status_code in [401, 403]:
                     self.token = self.get_new_token()
-                    logger.info("Got a new access token and retrying...")
-                elif hasattr(e, "response") and e.response.status_code == 500:
-                    if "Allowed memory size of" in str(e.response.content):
+                    logger.info("Got a new access token.")
+                elif status_code == 500:
+                    if "Allowed memory size of" in str(error_response.content):
                         url = url.replace("pageSize=100", "pageSize=1")
                         logger.info(f"***Memory Error changing page size to 1 : {url}")
                     else:
-                        logger.info(f"***Error HTTP: {e}")
                         url = url.replace("pageSize=100", "pageSize=5")
                         logger.info(f"***Changing page size to 5: {url}")
-                        time.sleep(60)
-                else:
-                    logger.error(f"Error occurred while making API request: {e}")
-                    if attempt < self.max_retries:
-                        time.sleep(60)
-                    else:
-                        raise Exception(
-                            "Max retries reached. Unable to establish a connection."
-                        )
+
+                delay = retry_delay(waits, base_delay=base_delay)
+                waits += 1
+                logger.info(f"Waiting {delay:.1f} seconds before the next try...")
+                time.sleep(delay)
+
+        raise Exception(f"Max retries reached ({self.max_retries})")


### PR DESCRIPTION
Quand tout le répertoire est mis à jour le DAG échoue vers 00:05 car les requêtes n'ont pas de timeout alors que l'INPI fait probablement une opération de maintenance.

De plus le DAG effectue des retries toutes les 60s 100 fois, soit en 1h 500 appels en échecs sur les 5 environnements. Avec un backoff on tombe à 40. Cela réduit la charge lors de problèmes côté RNE ou de 429.

Lors de 429 le délai est encore plus augmenté afin de laisser le temps au rate limit de passer.

Ajout de logs pour comprendre quelle erreur l'API RNE renvoie.

Live on dev-01 ✅ 